### PR TITLE
Add codecov file and split with flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+          flags: ${{ runner.os }}

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,17 @@
+component_management:
+  individual_components:
+    - component_id: "credentials"
+      paths:
+        - "credentials/"
+    - component_id: "crypto"
+      paths:
+        - "crypto/"
+    - component_id: "dids"
+      paths:
+        - "dids/"
+    - component_id: "common"
+      paths:
+        - "common/"
+
+comment:
+  layout: "header, diff, components"


### PR DESCRIPTION
# Overview
Adds a codecov file that splits coverage reports by component. Also splits the upload with the flag to indicate which platform was tested. 

# How Has This Been Tested?
See the codecov comment below. 

## References
* https://docs.codecov.com/docs/flags
* https://docs.codecov.com/docs/components