### PR TITLE
adding cred status list

### DIFF
--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -10,6 +10,8 @@ repositories {
   maven("https://repo.danubetech.com/repository/maven-public/")
 }
 
+val ktor_version = "2.3.4"
+
 dependencies {
   api("com.danubetech:verifiable-credentials-java:1.5.0")
 
@@ -20,6 +22,14 @@ dependencies {
   implementation("com.nfeld.jsonpathkt:jsonpathkt:2.0.1")
   implementation("com.nimbusds:nimbus-jose-jwt:9.34")
   implementation("decentralized-identity:did-common-java:1.9.0")
+
+  implementation("io.ktor:ktor-client-core:$ktor_version")
+  implementation("io.ktor:ktor-client-cio:$ktor_version")
+  implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+  implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
+  implementation("io.ktor:ktor-client-logging:$ktor_version")
+
+  testImplementation("io.ktor:ktor-client-mock:$ktor_version")
 
   testImplementation(kotlin("test"))
 }

--- a/credentials/src/main/kotlin/web5/sdk/credentials/StatusListCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/StatusListCredential.kt
@@ -1,0 +1,301 @@
+package web5.sdk.credentials
+
+import com.danubetech.verifiablecredentials.CredentialSubject
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.util.Base64
+import java.util.BitSet
+import java.util.Date
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Type alias representing the danubetech Status List 2021 Entry data model.
+ * This typealias simplifies the use of the [com.danubetech.verifiablecredentials.credentialstatus.StatusList2021Entry] class.
+ */
+public typealias StatusList2021Entry = com.danubetech.verifiablecredentials.credentialstatus.StatusList2021Entry
+
+/**
+ * Status purpose of a status list credential or a credential with a credential status.
+ */
+public enum class StatusPurpose {
+  REVOCATION,
+  SUSPENSION
+}
+
+/**
+ * The JSON property key for an encoded list.
+ */
+public const val ENCODED_LIST: String = "encodedList"
+
+/**
+ * The JSON property key for a status purpose.
+ */
+public const val STATUS_PURPOSE: String = "statusPurpose"
+
+/**
+ * `StatusListCredential` represents a digitally verifiable status list credential according to the
+ * [W3C Verifiable Credentials Status List v2021](https://www.w3.org/TR/vc-status-list/).
+ *
+ * When a status list is published, the result is a verifiable credential that encapsulates the status list.
+ *
+ */
+public object StatusListCredential {
+  /**
+   * Create a [StatusListCredential] with a specific purpose, e.g., for revocation.
+   *
+   * @param statusListCredentialId The id used for the resolvable path to the status list credential [String].
+   * @param issuer The issuer URI of the credential, as a [String].
+   * @param statusPurpose The status purpose of the status list cred, eg: revocation, as a [StatusPurpose].
+   * @param issuedCredentials The credentials to be included in the status list credential, eg: revoked credentials, list of type [VerifiableCredential].
+   * @return A [VerifiableCredential] instance.
+   *
+   * Example:
+   * ```
+   * val statusListCredential = StatusListCredential.create("http://example.com/statuslistcred/id123", "http://example.com/issuers/1", StatusPurpose.REVOCATION, listOf(vc1,vc2))
+   * ```
+   */
+  public fun create(
+    statusListCredentialId: String,
+    issuer: String,
+    statusPurpose: StatusPurpose,
+    issuedCredentials: List<VerifiableCredential>
+  ): VerifiableCredential {
+    val statusListIndexes = prepareCredentialsForStatusList(statusPurpose, issuedCredentials)
+    val bitString = bitstringGeneration(statusListIndexes)
+
+    val claims = mapOf(STATUS_PURPOSE to statusPurpose.toString().lowercase(), ENCODED_LIST to bitString)
+    val credSubject = CredentialSubject.builder()
+      .id(URI.create(statusListCredentialId))
+      .type("StatusList2021")
+      .claims(claims)
+      .build()
+
+    val vcDataModel = VcDataModel.builder()
+      .id(URI.create(statusListCredentialId))
+      .issuer(URI.create(issuer))
+      .issuanceDate(Date())
+      .context(URI.create("https://w3id.org/vc/status-list/2021/v1"))
+      .type("StatusList2021Credential")
+      .credentialSubject(credSubject)
+      .build()
+
+    return VerifiableCredential(vcDataModel)
+  }
+
+  /**
+   * Validates if a given credential is part of the status list represented by a [VerifiableCredential].
+   *
+   * @param credentialToValidate The [VerifiableCredential] to be validated against the status list.
+   * @param statusListCredential The [VerifiableCredential] representing the status list.
+   * @return A [Boolean] indicating whether the `credentialToValidate` is part of the status list.
+   *
+   * This function checks if the given `credentialToValidate`'s status list index is present in the expanded status list derived from the `statusListCredential`.
+   *
+   * Example:
+   * ```
+   * val isRevoked = validateCredentialInStatusList(credentialToCheck, statusListCred)
+   * ```
+   */
+  public fun validateCredentialInStatusList(
+    credentialToValidate: VerifiableCredential,
+    statusListCredential: VerifiableCredential
+  ): Boolean {
+    val statusListEntryValue: StatusList2021Entry =
+      StatusList2021Entry.fromJsonObject(credentialToValidate.vcDataModel.credentialStatus.jsonObject)
+
+    val statusLisCredStatusPurpose: String? =
+      statusListCredential.vcDataModel.credentialSubject.jsonObject[STATUS_PURPOSE] as? String?
+
+    requireNotNull(statusListEntryValue.statusPurpose)
+    requireNotNull(statusLisCredStatusPurpose)
+    require(statusListEntryValue.statusPurpose == statusLisCredStatusPurpose)
+
+    val compressedBitstring: String? =
+      statusListCredential.vcDataModel.credentialSubject.jsonObject[ENCODED_LIST] as? String?
+
+    requireNotNull(compressedBitstring)
+    require(compressedBitstring.isNotEmpty())
+
+    val credentialIndex = statusListEntryValue.statusListIndex
+    val expandedValues: List<String> = bitstringExpansion(compressedBitstring)
+
+    return expandedValues.any { it == credentialIndex }
+  }
+
+  /**
+   * Validates if a given credential is part of the status list.
+   *
+   * @param credentialToValidate The [VerifiableCredential] to be validated against the status list.
+   * @param httpClient An optional [HttpClient] for fetching the status list credential. If not provided, a default HTTP client will be used.
+   * @return A [Boolean] indicating whether the `credentialToValidate` is part of the status list.
+   *
+   * This function fetches the status list credential from a URL present in the `credentialToValidate`.
+   * It supports using either a user-provided `httpClient` or a default client when no client is passed in.
+   * The function then checks if the given `credentialToValidate`'s status list index is present in the expanded status list derived from the fetched status list credential.
+   *
+   * Example:
+   * ```
+   * val isRevoked = validateCredentialInStatusList(credentialToCheck)
+   * ```
+   */
+  public suspend fun validateCredentialInStatusList(
+    credentialToValidate: VerifiableCredential,
+    httpClient: HttpClient? = null // default HTTP client but can be overridden
+  ): Boolean {
+
+    var isDefaultClient = false
+    val clientToUse = httpClient ?: defaultHttpClient().also { isDefaultClient = true }
+
+    try {
+      val statusListEntryValue: StatusList2021Entry =
+        StatusList2021Entry.fromJsonObject(credentialToValidate.vcDataModel.credentialStatus.jsonObject)
+      val statusListCredential =
+        clientToUse.fetchStatusListCredential(statusListEntryValue.statusListCredential.toString())
+
+      return validateCredentialInStatusList(credentialToValidate, statusListCredential)
+    } finally {
+      if (isDefaultClient) {
+        clientToUse.close()
+      }
+    }
+  }
+
+  private fun defaultHttpClient(): HttpClient {
+    return HttpClient(CIO)
+  }
+
+  private suspend fun HttpClient.fetchStatusListCredential(url: String): VerifiableCredential {
+    try {
+      val response: io.ktor.client.statement.HttpResponse = this.get(url)
+      if (response.status.isSuccess()) {
+        val body = response.bodyAsText()
+        return VerifiableCredential.parseJwt(body)
+      } else {
+        throw ClientRequestException(response, "Failed to retrieve VerifiableCredentialType from $url")
+      }
+    } catch (e: ClientRequestException) {
+      throw Exception("Failed to fetch the status list credential due to a request error: ${e.message}", e)
+    } catch (e: ResponseException) {
+      throw Exception("Failed to fetch the status list credential due to a response error: ${e.message}", e)
+    }
+  }
+
+  /**
+   * Prepares a list of credentials for status list processing.
+   *
+   * This function:
+   * - Ensures all provided credentials use the `StatusList2021` format for their status.
+   * - Validates that all credentials use the `StatusList2021` in the `credentialStatus` property.
+   * - Assembles a list of `statusListIndex` values for the bitstring generation algorithm.
+   *
+   */
+  @Throws(Exception::class)
+  private fun prepareCredentialsForStatusList(
+    statusPurpose: StatusPurpose,
+    credentials: List<VerifiableCredential>
+  ): List<String> {
+    val duplicateSet = mutableSetOf<String>()
+    for (vc in credentials) {
+      requireNotNull(vc.vcDataModel.credentialStatus) { "no credential status found in credential" }
+
+      val statusListEntry: StatusList2021Entry =
+        StatusList2021Entry.fromJsonObject(vc.vcDataModel.credentialStatus.jsonObject)
+
+      require(statusListEntry.statusPurpose == statusPurpose.toString().lowercase()) { "status purpose mismatch" }
+
+      if (!duplicateSet.add(statusListEntry.statusListIndex)) {
+        throw Exception("duplicate entry found with index: ${statusListEntry.statusListIndex}")
+      }
+    }
+
+    return duplicateSet.toList()
+  }
+
+  /**
+   * Generates a compressed bitstring representation of the provided status list indexes.
+   *
+   * This function performs the following steps:
+   * 1. Initializes a list of bits with a minimum size of 16KB, where each bit is set to 0.
+   * 2. Iterates through the provided status list indexes, and for each index:
+   *    - Validates its value.
+   *    - Sets the corresponding bit in the bitstring to 1.
+   * 3. Compresses the generated bitstring using the GZIP compression algorithm.
+   * 4. Returns the base64-encoded representation of the compressed bitstring.
+   */
+  private fun bitstringGeneration(statusListIndexes: List<String>): String {
+    val duplicateCheck = mutableSetOf<Int>()
+
+    // 1. Let bitstring be a list of bits with a minimum size of 16KB, where each bit is initialized to 0 (zero).
+    val bitSetSize = 16 * 1024 * 8
+    val bitSet = BitSet(bitSetSize)
+
+    for (index in statusListIndexes) {
+      val indexInt = index.toIntOrNull()
+
+      if (indexInt == null || indexInt < 0) {
+        throw Exception("invalid status list index: $index")
+      }
+
+      if (indexInt >= bitSetSize) {
+        throw Exception("invalid status list index: $index, index is larger than the bitset size")
+      }
+
+      if (!duplicateCheck.add(indexInt)) {
+        throw Exception("duplicate status list index value found: $indexInt")
+      }
+
+      bitSet.set(indexInt)
+    }
+
+    val bitstringBinary = bitSet.toByteArray()
+    val baos = ByteArrayOutputStream()
+    GZIPOutputStream(baos).use { it.write(bitstringBinary) }
+    return Base64.getEncoder().encodeToString(baos.toByteArray())
+  }
+
+  /**
+   * Expands a compressed bitstring and produces a list of indices where the bit is set to 1.
+   *
+   * This function performs the following steps:
+   * 1. Decodes the provided compressed bitstring from its base64 representation.
+   * 2. Decompresses the decoded bitstring using the GZIP compression algorithm.
+   * 3. Iterates through the decompressed bitstring and collects the indices of bits set to 1.
+   */
+  @Throws(Exception::class)
+  private fun bitstringExpansion(compressedBitstring: String): List<String> {
+    val decoded: ByteArray
+    try {
+      decoded = Base64.getDecoder().decode(compressedBitstring)
+    } catch (e: IllegalArgumentException) {
+      throw Exception("decoding compressed bitstring", e)
+    }
+
+    val bitstringInputStream = ByteArrayInputStream(decoded)
+    val byteArrayOutputStream = ByteArrayOutputStream()
+
+    try {
+      GZIPInputStream(bitstringInputStream).use { it.copyTo(byteArrayOutputStream) }
+    } catch (e: Exception) {
+      throw Exception("unzipping status list bitstring using GZIP", e)
+    }
+
+    val unzipped = byteArrayOutputStream.toByteArray()
+    val b = BitSet.valueOf(unzipped)
+
+    val expanded = mutableListOf<String>()
+    for (i in 0 until b.length()) {
+      if (b[i]) expanded.add(i.toString())
+    }
+
+    return expanded
+  }
+}

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -1,6 +1,7 @@
 package web5.sdk.credentials
 
 import com.danubetech.verifiablecredentials.CredentialSubject
+import com.danubetech.verifiablecredentials.credentialstatus.CredentialStatus
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -148,7 +149,14 @@ public class VerifiableCredential(public val vcDataModel: VcDataModel) {
      * val vc = VerifiableCredential.create("ExampleCredential", "http://example.com/issuers/1", "http://example.com/subjects/1", myData)
      * ```
      */
-    public fun <T> create(type: String, issuer: String, subject: String, data: T): VerifiableCredential {
+    public fun <T> create(
+      type: String,
+      issuer: String,
+      subject: String,
+      data: T,
+      credentialStatus: CredentialStatus? = null
+    ): VerifiableCredential {
+
       val jsonData: JsonNode = objectMapper.valueToTree(data)
       val mapData: Map<String, Any> = when (jsonData.isObject) {
         true -> objectMapper.convertValue<Map<String, Any>>(jsonData)
@@ -166,6 +174,12 @@ public class VerifiableCredential(public val vcDataModel: VcDataModel) {
         .issuer(URI.create(issuer))
         .issuanceDate(Date())
         .credentialSubject(credentialSubject)
+        .apply {
+          credentialStatus?.let {
+            credentialStatus(it)
+            context(URI.create("https://w3id.org/vc/status-list/2021/v1"))
+          }
+        }
         .build()
 
       return VerifiableCredential(vcDataModel)
@@ -280,6 +294,21 @@ public class VerifiableCredential(public val vcDataModel: VcDataModel) {
       val vcDataModel = VcDataModel.fromMap(vcDataModelMap)
 
       return VerifiableCredential(vcDataModel)
+    }
+
+    /**
+     * Parses a JSON string into a [VerifiableCredential] instance.
+     *
+     * @param vcJson The verifiable credential JSON as a [String].
+     * @return A [VerifiableCredential] instance derived from the JSON.
+     *
+     * Example:
+     * ```
+     * val vc = VerifiableCredential.fromJson(vcJsonString)
+     * ```
+     */
+    public fun fromJson(vcJson: String): VerifiableCredential {
+      return VerifiableCredential(VcDataModel.fromJson(vcJson))
     }
   }
 }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/StatusListCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/StatusListCredentialTest.kt
@@ -1,0 +1,431 @@
+package web5.sdk.credentials
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.DidKey
+import java.io.File
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StatusListCredentialTest {
+
+  @Test
+  fun `should parse valid VerifiableCredential from specification example`() {
+    val specExampleRevocableVcText = File("src/test/testdata/revocableVc.json").readText()
+
+    val specExampleRevocableVc = VerifiableCredential.fromJson(
+      specExampleRevocableVcText
+    )
+
+    assertTrue(
+      specExampleRevocableVc.vcDataModel.contexts.containsAll(
+        listOf(
+          URI.create("https://www.w3.org/ns/credentials/v2"),
+          URI.create("https://www.w3.org/ns/credentials/examples/v2")
+        )
+      )
+    )
+
+    assertEquals(specExampleRevocableVc.type, "VerifiableCredential")
+    assertEquals(specExampleRevocableVc.issuer.toString(), "did:example:12345")
+    assertNotNull(specExampleRevocableVc.vcDataModel.credentialStatus)
+    assertEquals(specExampleRevocableVc.subject, "did:example:6789")
+    assertEquals(specExampleRevocableVc.vcDataModel.credentialSubject.type.toString(), "Person")
+
+    val credentialStatus: StatusList2021Entry =
+      StatusList2021Entry.fromJsonObject(specExampleRevocableVc.vcDataModel.credentialStatus.jsonObject)
+
+    assertEquals(credentialStatus.id.toString(), "https://example.com/credentials/status/3#94567")
+    assertEquals(credentialStatus.type.toString(), "BitStringStatusListEntry")
+    assertEquals(credentialStatus.statusPurpose.toString(), StatusPurpose.REVOCATION.toString().lowercase())
+    assertEquals(credentialStatus.statusListIndex, "94567")
+    assertEquals(credentialStatus.statusListCredential.toString(), "https://example.com/credentials/status/3")
+  }
+
+  @Test
+  fun `should create valid VerifiableCredential with a credential status`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val credWithCredStatus = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus
+    )
+
+    assertTrue(
+      credWithCredStatus.vcDataModel.contexts.containsAll(
+        listOf(
+          URI.create("https://www.w3.org/2018/credentials/v1"),
+          URI.create("https://w3id.org/vc/status-list/2021/v1")
+        )
+      )
+    )
+
+    assertEquals(credWithCredStatus.type, "StreetCred")
+    assertEquals(credWithCredStatus.issuer, issuerDid.uri)
+    assertNotNull(credWithCredStatus.vcDataModel.issuanceDate)
+    assertNotNull(credWithCredStatus.vcDataModel.credentialStatus)
+    assertEquals(credWithCredStatus.vcDataModel.credentialSubject.claims.get("localRespect"), "high")
+
+    val credStatus: StatusList2021Entry =
+      StatusList2021Entry.fromJsonObject(credWithCredStatus.vcDataModel.credentialStatus.jsonObject)
+
+    assertEquals(credStatus.id.toString(), "cred-with-status-id")
+    assertEquals(credStatus.type.toString(), "StatusList2021Entry")
+    assertEquals(credStatus.statusPurpose.toString(), StatusPurpose.REVOCATION.toString().lowercase())
+    assertEquals(credStatus.statusListIndex, "123")
+    assertEquals(credStatus.statusListCredential.toString(), "https://example.com/credentials/status/3")
+  }
+
+  @Test
+  fun `should generate StatusListCredential from multiple VerifiableCredentials`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val credentialStatus2 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("124")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc2 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus2
+    )
+
+    val statusListCredential = StatusListCredential.create(
+      "revocation-id",
+      issuerDid.uri,
+      StatusPurpose.REVOCATION,
+      listOf(vc1, vc2))
+
+    assertNotNull(statusListCredential)
+    assertTrue(
+      statusListCredential.vcDataModel.contexts.containsAll(
+        listOf(
+          URI.create("https://www.w3.org/2018/credentials/v1"),
+          URI.create("https://w3id.org/vc/status-list/2021/v1")
+        )
+      )
+    )
+    assertTrue(
+      statusListCredential.vcDataModel.types.containsAll(
+        listOf(
+          "VerifiableCredential",
+          "StatusList2021Credential"
+        )
+      )
+    )
+    assertEquals(statusListCredential.subject,"revocation-id")
+    assertEquals(statusListCredential.vcDataModel.credentialSubject.type, "StatusList2021")
+    assertEquals(
+      "revocation",
+      statusListCredential.vcDataModel.credentialSubject.jsonObject["statusPurpose"] as? String?
+    )
+
+    assertEquals(
+      "H4sIAAAAAAAA/2NgQAESAAPT1/8QAAAA",
+      statusListCredential.vcDataModel.credentialSubject.jsonObject["encodedList"] as? String?
+    )
+  }
+
+
+  @Test
+  fun `should fail when generating StatusListCredential with duplicate indexes`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val credentialStatus2 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc2 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus2
+    )
+
+    val exception = assertThrows<Exception> {
+      StatusListCredential.create(
+        "revocation-id",
+        issuerDid.uri,
+        StatusPurpose.REVOCATION,
+        listOf(vc1, vc2))
+    }
+
+    assertTrue(
+      exception
+        .message!!.contains("duplicate entry found with index: 123")
+    )
+  }
+
+  @Test
+  fun `should fail when generating StatusListCredential with negative index`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("-1")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val exception = assertThrows<Exception> {
+      StatusListCredential.create(
+        "revocation-id",
+        issuerDid.uri,
+        StatusPurpose.REVOCATION,
+        listOf(vc1))
+    }
+
+    assertTrue(
+      exception
+        .message!!.contains("invalid status list index: -1")
+    )
+  }
+
+  @Test
+  fun `should fail when generating StatusListCredential with an index larger than maximum size`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex(Int.MAX_VALUE.toString())
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val exception = assertThrows<Exception> {
+      StatusListCredential.create(
+        "revocation-id",
+        issuerDid.uri,
+        StatusPurpose.REVOCATION,
+        listOf(vc1))
+    }
+
+    assertTrue(
+      exception
+        .message!!.contains("invalid status list index: ${Int.MAX_VALUE}, index is larger than the bitset size")
+    )
+  }
+
+  @Test
+  fun `should validate if a credential exists in the status list`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val credentialStatus2 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("124")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc2 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus2
+    )
+
+    val credentialStatus3 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("125")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc3 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus3
+    )
+
+    val statusListCredential =
+      StatusListCredential.create(
+        "revocation-id",
+        issuerDid.uri,
+        StatusPurpose.REVOCATION,
+        listOf(vc1, vc2)
+      )
+
+    val revoked = StatusListCredential.validateCredentialInStatusList(vc1, statusListCredential)
+    assertTrue(revoked)
+
+    val revoked2 = StatusListCredential.validateCredentialInStatusList(vc2, statusListCredential)
+    assertTrue(revoked2)
+
+    val revoked3 = StatusListCredential.validateCredentialInStatusList(vc3, statusListCredential)
+    assertFalse(revoked3)
+  }
+
+  @Test
+  fun `should asynchronously validate if a credential is in the status list using a mock HTTP client`() = runBlocking {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val credentialStatus1 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("123")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc1 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus = credentialStatus1
+    )
+
+    val credentialStatus2 = StatusList2021Entry.builder()
+      .id(URI.create("cred-with-status-id"))
+      .statusPurpose("revocation")
+      .statusListIndex("124")
+      .statusListCredential(URI.create("https://example.com/credentials/status/3"))
+      .build()
+
+    val vc2 = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      credentialStatus2
+    )
+
+    val statusListCredential =
+      StatusListCredential.create(
+        "revocation-id",
+        issuerDid.uri,
+        StatusPurpose.REVOCATION,
+        listOf(vc1)
+      )
+
+    val slcJwt = statusListCredential.sign(issuerDid)
+    assertNotNull(slcJwt)
+
+    val mockedHttpClient = HttpClient(MockEngine) {
+      engine {
+        addHandler { request ->
+          when (request.url.fullPath) {
+            "/credentials/status/3" -> {
+              val responseBody = slcJwt
+              respond(responseBody, headers = headersOf("Content-Type", "application/json"))
+            }
+
+            else -> error("Unhandled ${request.url.fullPath}")
+          }
+        }
+      }
+    }
+
+    val revoked = StatusListCredential.validateCredentialInStatusList(vc1, mockedHttpClient)
+    assertTrue(revoked)
+
+    val revoked2 = StatusListCredential.validateCredentialInStatusList(vc2, mockedHttpClient)
+    assertFalse(revoked2)
+  }
+}

--- a/credentials/src/test/testdata/revocableVc.json
+++ b/credentials/src/test/testdata/revocableVc.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://example.com/credentials/23894672394",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:example:12345",
+  "validFrom": "2021-04-05T14:27:42Z",
+  "credentialStatus": {
+    "id": "https://example.com/credentials/status/3#94567",
+    "type": "BitStringStatusListEntry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "https://example.com/credentials/status/3"
+  },
+  "credentialSubject": {
+    "id": "did:example:6789",
+    "type": "Person"
+  }
+}


### PR DESCRIPTION
# Overview
Cred Credential Status Lists for Revocation (or Suspension)

# Description
This change allows for generation of a status list credential. *NOTE* This is a stateless SDK and it is up to the issuer to set the IDs and host these creds for public retrieval


```
  /**
   * Create a [StatusListCredential] with a specific purpose, e.g., for revocation.
   *
   * @param statusListCredentialId The id used for the resolvable path to the status list credential [String].
   * @param issuer The issuer URI of the credential, as a [String].
   * @param statusPurpose The status purpose of the status list cred, eg: revocation, as a [StatusPurpose].
   * @param issuedCredentials The credentials to be included in the status list credential, eg: revoked credentials, list of type [VerifiableCredential].
   * @return A [VerifiableCredential] instance.
   *
   * Example:
   * ```
   * val statusListCredential = StatusListCredential.create("http://example.com/statuslistcred/id123", "http://example.com/issuers/1", StatusPurpose.REVOCATION, listOf(vc1,vc2))
   * ```
   */
```


## References
https://www.w3.org/TR/vc-status-list/
