### PR TITLE
Secp256k1 low-s

### DIFF
--- a/common/src/main/kotlin/web5/sdk/common/Convert.kt
+++ b/common/src/main/kotlin/web5/sdk/common/Convert.kt
@@ -17,6 +17,7 @@ public val B64URL_ENCODER: Base64.Encoder = Base64.getUrlEncoder()
 public enum class EncodingFormat {
   Base64Url,
   Base58Btc
+  // TODO: add EncodingFormat for Base64Url_Pad and Base64Url_NoPad
 }
 
 /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
@@ -46,16 +46,16 @@ public object Crypto {
   )
 
   private val keyGeneratorsByMultiCodec = mapOf<Int, KeyGenerator>(
-    Ed25519.privMultiCodec to Ed25519,
-    Ed25519.pubMulticodec to Ed25519,
-    Secp256k1.privMultiCodec to Secp256k1,
-    Secp256k1.pubMulticodec to Secp256k1
+    Ed25519.PRIV_MULTICODEC to Ed25519,
+    Ed25519.PUB_MULTICODEC to Ed25519,
+    Secp256k1.PRIV_MULTICODEC to Secp256k1,
+    Secp256k1.PUB_MULTICODEC to Secp256k1
   )
 
   private val multiCodecsByAlgorithm = mapOf(
-    Pair(Secp256k1.algorithm, null) to Secp256k1.pubMulticodec,
-    Pair(Secp256k1.algorithm, Curve.SECP256K1) to Secp256k1.pubMulticodec,
-    Pair(Ed25519.algorithm, Curve.Ed25519) to Ed25519.pubMulticodec
+    Pair(Secp256k1.algorithm, null) to Secp256k1.PUB_MULTICODEC,
+    Pair(Secp256k1.algorithm, Curve.SECP256K1) to Secp256k1.PUB_MULTICODEC,
+    Pair(Ed25519.algorithm, Curve.Ed25519) to Ed25519.PUB_MULTICODEC
   )
 
   private val signers = mapOf<CryptoAlgorithm, Signer>(

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -13,10 +13,10 @@ import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
 import com.nimbusds.jose.util.Base64URL
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import web5.sdk.common.Convert
+import web5.sdk.crypto.Ed25519.PRIV_MULTICODEC
+import web5.sdk.crypto.Ed25519.PUB_MULTICODEC
 import web5.sdk.crypto.Ed25519.algorithm
 import web5.sdk.crypto.Ed25519.keyType
-import web5.sdk.crypto.Ed25519.privMultiCodec
-import web5.sdk.crypto.Ed25519.pubMulticodec
 import java.security.GeneralSecurityException
 import java.security.SignatureException
 
@@ -31,16 +31,16 @@ import java.security.SignatureException
  *
  * @property algorithm Specifies the JWS algorithm type. For Ed25519, this is `EdDSA`.
  * @property keyType Specifies the key type. For Ed25519, this is `OKP`.
- * @property pubMulticodec A byte array representing the multicodec prefix for an Ed25519 public key.
- * @property privMultiCodec A byte array representing the multicodec prefix for an Ed25519 private key.
+ * @property PUB_MULTICODEC A byte array representing the multicodec prefix for an Ed25519 public key.
+ * @property PRIV_MULTICODEC A byte array representing the multicodec prefix for an Ed25519 private key.
  */
 
 public object Ed25519 : KeyGenerator, Signer {
   override val algorithm: Algorithm = JWSAlgorithm.EdDSA
   override val keyType: KeyType = KeyType.OKP
 
-  public const val pubMulticodec: Int = 0xed
-  public const val privMultiCodec: Int = 0x1300
+  public const val PUB_MULTICODEC: Int = 0xed
+  public const val PRIV_MULTICODEC: Int = 0x1300
 
   /**
    * Generates a private key utilizing the Ed25519 algorithm.

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -17,9 +17,10 @@ import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.crypto.signers.ECDSASigner
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator
 import org.bouncycastle.jce.ECNamedCurveTable
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec
 import org.bouncycastle.math.ec.ECPoint
-import web5.sdk.crypto.Secp256k1.privMultiCodec
-import web5.sdk.crypto.Secp256k1.pubMulticodec
+import web5.sdk.crypto.Secp256k1.PRIV_MULTICODEC
+import web5.sdk.crypto.Secp256k1.PUB_MULTICODEC
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.security.Security
@@ -35,7 +36,7 @@ import java.security.SignatureException
  * ### Key Points:
  * - Utilizes the ES256K algorithm for signing JWTs.
  * - Utilizes BouncyCastle as the underlying security provider.
- * - Public and private keys can be encoded with [pubMulticodec] and [privMultiCodec] respectively.
+ * - Public and private keys can be encoded with [PUB_MULTICODEC] and [PRIV_MULTICODEC] respectively.
  *
  * ### Example Usage:
  * ```
@@ -64,19 +65,19 @@ public object Secp256k1 : KeyGenerator, Signer {
   override val keyType: KeyType = KeyType.EC
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
-  public const val pubMulticodec: Int = 0xe7
+  public const val PUB_MULTICODEC: Int = 0xe7
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L169). */
-  public const val privMultiCodec: Int = 0x1301
+  public const val PRIV_MULTICODEC: Int = 0x1301
 
   /**  uncompressed key leading byte. */
-  public const val uncompressedKeyIdentifier: Byte = 0x04
+  public const val UNCOMPRESSED_KEY_ID: Byte = 0x04
 
   /** Compressed key leading byte that indicates whether the Y coordinate is even. */
-  public const val compressedKeyEvenYIdentifier: Byte = 0x02
+  public const val COMP_KEY_EVEN_Y_ID: Byte = 0x02
 
   /** Compressed key leading byte that indicates whether the Y coordinate is odd. */
-  public const val compressedKeyOddYIdentifier: Byte = 0x03
+  public const val COMP_KEY_ODD_Y_ID: Byte = 0x03
 
   /**
    * Size of an uncompressed public key in bytes.
@@ -85,7 +86,7 @@ public object Secp256k1 : KeyGenerator, Signer {
    * followed by 32 bytes for the X coordinate and 32 bytes for the Y coordinate.
    * Thus, an uncompressed key is 65 bytes in size.
    */
-  public const val uncompressedKeySize: Int = 65
+  public const val UNCOMPRESSED_KEY_SIZE: Int = 65
 
   /**
    * The byte size of a compressed public key.
@@ -99,7 +100,7 @@ public object Secp256k1 : KeyGenerator, Signer {
    * This constant can be utilized for validating the length of a byte array supposed to
    * represent a compressed public key, ensuring it conforms to the expected format.
    */
-  public const val compressedKeySize: Int = 33
+  public const val COMPRESSED_KEY_SIZE: Int = 33
 
   /**
    * Range that defines the position of the X coordinate in an uncompressed public key byte array.
@@ -116,6 +117,16 @@ public object Secp256k1 : KeyGenerator, Signer {
    * of an uncompressed public key, following the X coordinate.
    */
   public val publicKeyYRange: IntRange = 33..64
+
+  /**
+   * contains the paramaters of the curve's equation (e.g. n, g etc.)
+   */
+  private val spec: ECNamedCurveParameterSpec = ECNamedCurveTable.getParameterSpec("secp256k1")
+
+  /**
+   * another way that parameters of a curve's equation are represented.
+   */
+  private val curveParams: ECDomainParameters = ECDomainParameters(spec.curve, spec.g, spec.n)
 
   /**
    * Generates a private key using the SECP256K1 curve and ES256K algorithm.
@@ -154,11 +165,10 @@ public object Secp256k1 : KeyGenerator, Signer {
     val xBytes = ecKey.x.decode()
     val yBytes = ecKey.y.decode()
 
-    return byteArrayOf(uncompressedKeyIdentifier) + xBytes + yBytes
+    return byteArrayOf(UNCOMPRESSED_KEY_ID) + xBytes + yBytes
   }
 
   override fun bytesToPrivateKey(privateKeyBytes: ByteArray): JWK {
-    val spec = ECNamedCurveTable.getParameterSpec("secp256k1")
     var pointQ: ECPoint = spec.g.multiply(BigInteger(1, privateKeyBytes))
 
     pointQ = pointQ.normalize()
@@ -202,11 +212,8 @@ public object Secp256k1 : KeyGenerator, Signer {
    *                                  for the signing process.
    */
   override fun sign(privateKey: JWK, payload: ByteArray, options: SignOptions?): ByteArray {
-    val spec = ECNamedCurveTable.getParameterSpec("secp256k1")
-    val domainParams = ECDomainParameters(spec.curve, spec.g, spec.n)
-
     val privateKeyBigInt = privateKey.toECKey().d.decodeToBigInteger()
-    val privateKeyParams = ECPrivateKeyParameters(privateKeyBigInt, domainParams)
+    val privateKeyParams = ECPrivateKeyParameters(privateKeyBigInt, curveParams)
 
     // generates k value deterministically using the private key and message hash, ensuring that signing the same
     // message with the same private key will always produce the same signature.
@@ -222,17 +229,17 @@ public object Secp256k1 : KeyGenerator, Signer {
 
     // ensure s is always in the bottom half of n.
     // why? - An ECDSA signature for a given message and private key is not strictly unique. Specifically, if
-    //       (r,s) is a valid signature, then (r, mod(-s, n)) is also a valid signature. This means there
-    //       are two valid signatures for every message/private key pair: one with a "low" s value and one
-    //       with a "high" s value. standardizing acceptance of only 1 of the 2 prevents signature malleability
-    //       issues. Signature malleability is a notable concern in Bitcoin which introduced the low-s
-    //       requirement for all signatures in version 0.11.1.
+    //      (r,s) is a valid signature, then (r, mod(-s, n)) is also a valid signature. This means there
+    //      are two valid signatures for every message/private key pair: one with a "low" s value and one
+    //      with a "high" s value. standardizing acceptance of only 1 of the 2 prevents signature malleability
+    //      issues. Signature malleability is a notable concern in Bitcoin which introduced the low-s
+    //      requirement for all signatures in version 0.11.1.
     // n - a large prime number that defines the maximum number of points that can be created by
-    //     adding the base point, G, to itself repeatedly. The base point
+    //    adding the base point, G, to itself repeatedly. The base point
     // G - AKA generator point. a predefined point on an elliptic curve.
     // TODO: consider making lowS a boolean option.
-    val halfN = domainParams.n.shiftRight(1)
-    val sBigint = if (initialSBigint >= halfN) domainParams.n.subtract(initialSBigint) else initialSBigint
+    val halfN = curveParams.n.shiftRight(1)
+    val sBigint = if (initialSBigint >= halfN) curveParams.n.subtract(initialSBigint) else initialSBigint
 
     // Secp256k1 signatures are always 64 bytes. When using BigInteger.toByteArray() in Java/Kotlin,
     // there can sometimes be a leading zero byte added. This occurs when the most significant bit of the most
@@ -246,13 +253,10 @@ public object Secp256k1 : KeyGenerator, Signer {
   }
 
   override fun verify(publicKey: JWK, signedPayload: ByteArray, signature: ByteArray, options: VerifyOptions?) {
-    val spec = ECNamedCurveTable.getParameterSpec("secp256k1")
-    val domainParams = ECDomainParameters(spec.curve, spec.g, spec.n)
-
     val publicKeyBytes = publicKeyToBytes(publicKey)
     val publicKeyPoint = spec.curve.decodePoint(publicKeyBytes)
 
-    val publicKeyParams = ECPublicKeyParameters(publicKeyPoint, domainParams)
+    val publicKeyParams = ECPublicKeyParameters(publicKeyPoint, curveParams)
 
     // generates k value deterministically using the private key and message hash, ensuring that signing the same
     // message with the same private key will always produce the same signature.
@@ -322,14 +326,14 @@ public object Secp256k1 : KeyGenerator, Signer {
    * @throws IllegalArgumentException if the input byte array is not of expected length or doesn't start with 0x04.
    */
   public fun compressPublicKey(publicKeyBytes: ByteArray): ByteArray {
-    require(publicKeyBytes.size == uncompressedKeySize && publicKeyBytes[0] == uncompressedKeyIdentifier) {
+    require(publicKeyBytes.size == UNCOMPRESSED_KEY_SIZE && publicKeyBytes[0] == UNCOMPRESSED_KEY_ID) {
       "Public key must be 65 bytes long and start with 0x04"
     }
 
     val xBytes = publicKeyBytes.sliceArray(publicKeyXRange)
     val yBytes = publicKeyBytes.sliceArray(publicKeyYRange)
 
-    val prefix = if (yBytes.last() % 2 == 0) compressedKeyEvenYIdentifier else compressedKeyOddYIdentifier
+    val prefix = if (yBytes.last() % 2 == 0) COMP_KEY_EVEN_Y_ID else COMP_KEY_ODD_Y_ID
     return byteArrayOf(prefix) + xBytes
   }
 
@@ -337,16 +341,12 @@ public object Secp256k1 : KeyGenerator, Signer {
    * Inflates a compressed public key.
    */
   public fun inflatePublicKey(publicKeyBytes: ByteArray): ByteArray {
-    require(publicKeyBytes.size == compressedKeySize) { "Invalid key size" }
+    require(publicKeyBytes.size == COMPRESSED_KEY_SIZE) { "Invalid key size" }
 
-    val spec = ECNamedCurveTable.getParameterSpec("secp256k1")
-    val curve = spec.curve
-
-    val ecPoint = curve.decodePoint(publicKeyBytes)
+    val ecPoint = spec.curve.decodePoint(publicKeyBytes)
     val xBytes = ecPoint.rawXCoord.encoded
     val yBytes = ecPoint.rawYCoord.encoded
 
-    return byteArrayOf(uncompressedKeyIdentifier) + xBytes + yBytes
+    return byteArrayOf(UNCOMPRESSED_KEY_ID) + xBytes + yBytes
   }
-
 }

--- a/dids/src/main/kotlin/web5/sdk/dids/DidResolvers.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidResolvers.kt
@@ -19,7 +19,8 @@ public object DidResolvers {
 
   // A mutable map to store method-specific DID resolvers.
   private val methodResolvers = mutableMapOf<String, DidResolver>(
-    DidKey.methodName to DidKey.Companion::resolve
+    DidKey.methodName to DidKey.Companion::resolve,
+    DidIonManager.methodName to DidIonManager.Default::resolve
   )
 
   /**


### PR DESCRIPTION
Ensures that `Secp256k1.sign` always returns the low-s signature

> [!NOTE]
> It's **highly unlikely** that AWS KMS or Cloud KMS natively supports guaranteed low-s signatures. Neither KMS' support deterministic k defined in [RFC6979](https://datatracker.ietf.org/doc/html/rfc6979) either. 
> 
> It's worth mentioning that lack of cloud KMS support isn't a deal breaker as the math required to compute low-s from high-s does not require any private key material. However, lack of deterministic-k support may be a deal breaker specifically w.r.t. managing ION update and recovery keys in a cloud KMS if ION requires deterministic signatures

## Background
An `ECDSA` signature for a given message and private key is not strictly unique. Specifically, if `(r,s)` is a valid signature, then `(r, mod(-s, n))` is also a valid signature. 

This means there are two valid signatures for every message/private key pair: one with a "low" s value and one with a "high" s value. standardizing acceptance of only 1 of the 2 prevents signature malleability issues. 

Signature malleability is a notable concern in Bitcoin which introduced the low-s requirement for all signatures in version 0.11.1.

---

So, why does this matter?  potentially transaction malleability? - 

Transaction malleability is an issue where the transaction ID (`txid`) can change after the transaction has been created but before it's been added to the block. If someone modifies the signature of a transaction (e.g. by using the high-s counterpart), it changes the `txid` without invalidating the transaction. 

---
     
## Rando helpful stuff
* `n` - a large prime number that defines the maximum number of points that can be created by adding the base point, G, to itself repeatedly. The base point
* `G` - AKA generator point. a predefined point on an elliptic curve.