### PR TITLE
Support DID Ion Recovery and Deactivate 

### DIFF
--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -11,15 +11,50 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.DidIonHandle
 import web5.sdk.dids.DidKey
 import java.text.ParseException
+import kotlin.test.Ignore
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 data class StreetCredibility(val localRespect: String, val legit: Boolean)
 class VerifiableCredentialTest {
+  @Test
+  @Ignore("Testing with a prev created ion did")
+  fun `create a vc with a previously created DID in the key manager`() {
+    val keyManager = AwsKeyManager()
+    val didUri =
+      "did:ion:EiCTb6TakNEaBkYK0ZVtCC26mdv8mGZ8Z7YnbsSf-kiMyg" +
+        ":eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiIwMzlhZTc" +
+        "xYy04OTZjLTQ2MzgtYjA3My0zYTQyM2IwMjhiMDEiLCJwdWJsaWNLZXlKd2siOnsiYWxnIjoiRVMyNTZLIiwiY3J2Ijoic2VjcDI1NmsxIiw" +
+        "ia2lkIjoiYWxpYXMvTzNmZUVhSDlaTVFmdkg3cTFkSUw3OFNxUmRJWkhnVUJlcFU3c1RtbHY1OCIsImt0eSI6IkVDIiwidXNlIjoic2lnIiw" +
+        "ieCI6IllwbTNZWS1oVnNqWjV2ME83aGRhZS1WVi1DRm1Ib0hldWFZODAtV08wS0UiLCJ5IjoiUnU5QlA2RzctU0lxU3E0MFdUenk5MnpiWXd" +
+        "aRHBuVmlDUWxRSHpNWVQzVSJ9LCJwdXJwb3NlcyI6WyJhc3NlcnRpb25NZXRob2QiXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn1dLCJzZXJ" +
+        "2aWNlcyI6W119fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNsaVVIbHBQQjE0VVpkVzk4S250aG8zV2YxRjQxOU83cFhSMGhPeFAzRkNnIn0" +
+        "sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlEU2FMNHZVNElzNmxDalp4YVp6Zl9lWFFMU3V5T3E5T0pNbVJHa2FFTzRCQSIsInJlY29" +
+        "2ZXJ5Q29tbWl0bWVudCI6IkVpQzI0TFljVEdRN1JzaDdIRUl2TXQ0MGNGbmNhZGZReTdibDNoa3k0RkxUQ2cifX0"
+    val issuerDid = DidIonHandle(didUri, keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val vc = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true)
+    )
+
+    val vcJwt = vc.sign(issuerDid)
+
+    assertDoesNotThrow {
+      VerifiableCredential.verify(vcJwt)
+    }
+  }
+
   @Test
   fun `create works`() {
     val keyManager = InMemoryKeyManager()

--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -294,7 +294,7 @@ public sealed class DidIonManager(
   /**
    * Updates an ION did with the given [options]. The update key must be available in the [keyManager].
    */
-  public fun update(keyManager: KeyManager, options: UpdateDidIonOptions): IonUpdateMetadata {
+  public fun update(keyManager: KeyManager, options: UpdateDidIonOptions): IonUpdateResult {
     val (updateOp, newUpdateKeyAlias) = createUpdateOperation(keyManager, options)
     val response: HttpResponse = runBlocking {
       client.post(operationsEndpoint) {
@@ -304,7 +304,7 @@ public sealed class DidIonManager(
     }
     val opBody = runBlocking { response.bodyAsText() }
     if (response.status.isSuccess()) {
-      return IonUpdateMetadata(
+      return IonUpdateResult(
         operationsResponseBody = opBody,
         updateKeyAlias = newUpdateKeyAlias,
       )
@@ -537,7 +537,7 @@ public sealed class DidIonManager(
    * Depending on the options provided, will create new keys using [keyManager]. See [RecoverDidIonOptions] for more
    * details.
    */
-  public fun recover(keyManager: KeyManager, options: RecoverDidIonOptions): RecoverResult {
+  public fun recover(keyManager: KeyManager, options: RecoverDidIonOptions): IonRecoverResult {
     val (recoverOp, keyAliases) = createRecoverOperation(keyManager, options)
 
     val response: HttpResponse = runBlocking {
@@ -550,7 +550,7 @@ public sealed class DidIonManager(
     val opBody = runBlocking {
       response.bodyAsText()
     }
-    return RecoverResult(
+    return IonRecoverResult(
       keyAliases = keyAliases,
       recoverOperation = recoverOp,
       operationsResponse = opBody,
@@ -560,7 +560,7 @@ public sealed class DidIonManager(
   /**
    * Deactivates an ION did with the given [options]. The `recoveryKeyAlias` value must be available in the [keyManager].
    */
-  public fun deactivate(keyManager: KeyManager, options: DeactivateDidIonOptions): DeactivateResult {
+  public fun deactivate(keyManager: KeyManager, options: DeactivateDidIonOptions): IonDeactivateResult {
     val deactivateOp = createDeactivateOperation(keyManager, options)
 
     val response: HttpResponse = runBlocking {
@@ -574,7 +574,7 @@ public sealed class DidIonManager(
       response.bodyAsText()
     }
 
-    return DeactivateResult(
+    return IonDeactivateResult(
       deactivateOperation = deactivateOp,
       operationsResponse = opBody,
     )
@@ -590,14 +590,14 @@ public sealed class DidIonManager(
 /**
  * Data associated with the [DidIonManager.deactivate] call. Useful for debugging and testing purposes.
  */
-public class DeactivateResult(
+public class IonDeactivateResult(
   public val deactivateOperation: SidetreeDeactivateOperation,
   public val operationsResponse: String)
 
 /**
  * All the data associated with the [recover] call. Useful for advanced, and debugging, purposes.
  */
-public class RecoverResult(
+public class IonRecoverResult(
   public val keyAliases: KeyAliases,
   public val recoverOperation: SidetreeRecoverOperation,
   public val operationsResponse: String)
@@ -641,7 +641,7 @@ private fun JWK.reveal(): Reveal {
 /**
  * Metadata related to the update of an ion DID.
  */
-public data class IonUpdateMetadata(
+public data class IonUpdateResult(
   public val operationsResponseBody: String,
   public val updateKeyAlias: String
 )

--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -365,8 +365,7 @@ public sealed class DidIonManager(
   private fun deltaHash(updateOpDeltaObject: Delta): String {
     val canonicalized = canonicalized(updateOpDeltaObject)
     val deltaHashBytes = Multihash.sum(Multicodec.SHA2_256, canonicalized).getOrThrow().bytes()
-    val deltaHash = Base64URL.encode(deltaHashBytes).toString()
-    return deltaHash
+    return Base64URL.encode(deltaHashBytes).toString()
   }
 
   private fun createOperation(keyManager: KeyManager, options: CreateDidIonOptions?)
@@ -538,8 +537,8 @@ public sealed class DidIonManager(
    * Depending on the options provided, will create new keys using [keyManager]. See [RecoverDidIonOptions] for more
    * details.
    */
-  public fun recover(keyManager: KeyManager, opts: RecoverDidIonOptions): RecoverResult {
-    val (recoverOp, keyAliases) = createRecoverOperation(keyManager, opts)
+  public fun recover(keyManager: KeyManager, options: RecoverDidIonOptions): RecoverResult {
+    val (recoverOp, keyAliases) = createRecoverOperation(keyManager, options)
 
     val response: HttpResponse = runBlocking {
       client.post(operationsEndpoint) {
@@ -561,8 +560,8 @@ public sealed class DidIonManager(
   /**
    * Deactivates an ION did with the given [options]. The `recoveryKeyAlias` value must be available in the [keyManager].
    */
-  public fun deactivate(keyManager: KeyManager, opts: DeactivateDidIonOptions): DeactivateResult {
-    val deactivateOp = createDeactivateOperation(keyManager, opts)
+  public fun deactivate(keyManager: KeyManager, options: DeactivateDidIonOptions): DeactivateResult {
+    val deactivateOp = createDeactivateOperation(keyManager, options)
 
     val response: HttpResponse = runBlocking {
       client.post(operationsEndpoint) {
@@ -589,7 +588,7 @@ public sealed class DidIonManager(
 }
 
 /**
- * Data associated with the [deactivate] call. Useful for debugging and testing purposes.
+ * Data associated with the [DidIonManager.deactivate] call. Useful for debugging and testing purposes.
  */
 public class DeactivateResult(
   public val deactivateOperation: SidetreeDeactivateOperation,

--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -430,7 +430,7 @@ public sealed class DidIonManager(
           id = verificationMethodId,
           type = "JsonWebKey2020",
           publicKeyJwk = verificationJwk,
-          purposes = listOf(PublicKeyPurpose.AUTHENTICATION),
+          purposes = listOf(PublicKeyPurpose.ASSERTION_METHOD),
         ),
         alias
       )

--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -32,6 +32,7 @@ import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.ion.model.AddPublicKeysAction
 import web5.sdk.dids.ion.model.AddServicesAction
 import web5.sdk.dids.ion.model.Commitment
+import web5.sdk.dids.ion.model.DeactivateUpdateSignedData
 import web5.sdk.dids.ion.model.Delta
 import web5.sdk.dids.ion.model.Document
 import web5.sdk.dids.ion.model.InitialState
@@ -46,6 +47,7 @@ import web5.sdk.dids.ion.model.ReplaceAction
 import web5.sdk.dids.ion.model.Reveal
 import web5.sdk.dids.ion.model.Service
 import web5.sdk.dids.ion.model.SidetreeCreateOperation
+import web5.sdk.dids.ion.model.SidetreeDeactivateOperation
 import web5.sdk.dids.ion.model.SidetreeRecoverOperation
 import web5.sdk.dids.ion.model.SidetreeUpdateOperation
 import web5.sdk.dids.ion.model.UpdateOperationSignedData
@@ -113,12 +115,35 @@ public data class UpdateDidIonOptions(
  * The options when recovering an ION did.
  */
 public class RecoverDidIonOptions(
-  public val didString: String,
+  public val did: String,
   public val recoveryKeyAlias: String,
-  public val document: Document,
-) {
-  internal fun toPatches(): List<PatchAction> = listOf(ReplaceAction(document))
+  public override val verificationPublicKey: PublicKey? = null,
+  public val updatePublicJwk: JWK? = null,
+  public val recoveryPublicJwk: JWK? = null,
+  public override val verificationMethodId: String? = null,
+  public val servicesToAdd: Iterable<Service> = emptySet(),
+) : VerificationPublicKeyOption {
+  internal fun toPatches(verificationPublicKey: PublicKey): List<PatchAction> = listOf(
+    ReplaceAction(
+      Document(
+        publicKeys = listOf(
+          verificationPublicKey
+        ),
+        services = servicesToAdd
+      )
+    )
+  )
 }
+
+/**
+ * Options when deactivating an ION did.
+ *
+ * [recoveryKeyAlias] is the alias within the keyManager to use when signing. It must match the recovery used with the
+ * last recovery operation.
+ * [did] is the DID that will be deactivated. E.g. "did:ion:123123".
+ */
+public class DeactivateDidIonOptions(public val recoveryKeyAlias: String, public val did: String)
+
 
 /**
  * Provides a specific implementation for creating and resolving "did:ion" method Decentralized Identifiers (DIDs).
@@ -319,8 +344,8 @@ public sealed class DidIonManager(
 
     val base64UrlEncodedSignature = Base64URL(Convert(signatureBytes).toBase64Url(padding = false))
     return JWSObject(
-      header.toBase64URL(),
-      payload.toBase64URL(),
+      jwsObject.header.toBase64URL(),
+      jwsObject.payload.toBase64URL(),
       base64UrlEncodedSignature,
     )
   }
@@ -334,42 +359,27 @@ public sealed class DidIonManager(
 
   private fun createOperation(keyManager: KeyManager, options: CreateDidIonOptions?)
     : Pair<SidetreeCreateOperation, KeyAliases> {
-    val updatePublicJwk: JWK = options?.updatePublicJwk ?: keyManager.getPublicKey(
-      keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
-    )
+    val (updatePublicJwk, updateKeyAlias) = if (options?.updatePublicJwk == null) {
+      val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+      Pair(keyManager.getPublicKey(alias), alias)
+    } else {
+      Pair(options.updatePublicJwk, null)
+    }
 
     val publicKeyCommitment = updatePublicJwk.commitment()
 
-    val verificationMethodId = when (options?.verificationMethodId) {
-      null -> UUID.randomUUID().toString()
-      else -> {
-        validateVerificationMethodId(options.verificationMethodId)
-        options.verificationMethodId
-      }
-    }
-    val verificationPublicKey = if (options?.verificationPublicKey == null) {
-      val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
-      val verificationJwk = keyManager.getPublicKey(alias)
-      PublicKey(
-        id = verificationMethodId,
-        type = "JsonWebKey2020",
-        publicKeyJwk = verificationJwk,
-        purposes = listOf(PublicKeyPurpose.AUTHENTICATION),
-      )
-    } else {
-      options.verificationPublicKey
-    }
+    val (verificationPublicKey, verificationKeyAlias) = getVerificationPublicKeyOrDefault(options, keyManager)
     val patches = listOf(ReplaceAction(Document(listOf(verificationPublicKey))))
     val createOperationDelta = Delta(
       patches = patches,
       updateCommitment = publicKeyCommitment
     )
 
-    val recoveryPublicJwk = if (options?.recoveryPublicJwk == null) {
+    val (recoveryPublicJwk, recoveryKeyAlias) = if (options?.recoveryPublicJwk == null) {
       val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
-      keyManager.getPublicKey(alias)
+      Pair(keyManager.getPublicKey(alias), alias)
     } else {
-      options.recoveryPublicJwk
+      Pair(options.recoveryPublicJwk, null)
     }
     val recoveryCommitment = recoveryPublicJwk.commitment()
 
@@ -383,12 +393,39 @@ public sealed class DidIonManager(
         delta = createOperationDelta,
       ),
       KeyAliases(
-        updateKeyAlias = updatePublicJwk.keyID,
-        verificationKeyAlias = verificationPublicKey.publicKeyJwk.keyID,
-        recoveryKeyAlias = recoveryPublicJwk.keyID
+        updateKeyAlias = updateKeyAlias,
+        verificationKeyAlias = verificationKeyAlias,
+        recoveryKeyAlias = recoveryKeyAlias
       )
     )
   }
+
+  private fun getVerificationMethodIdOrDefault(options: VerificationPublicKeyOption?) =
+    when (options?.verificationMethodId) {
+      null -> UUID.randomUUID().toString()
+      else -> {
+        validateVerificationMethodId(options.verificationMethodId!!)
+        options.verificationMethodId!!
+      }
+    }
+
+  private fun getVerificationPublicKeyOrDefault(options: VerificationPublicKeyOption?, keyManager: KeyManager) =
+    if (options?.verificationPublicKey == null) {
+      val verificationMethodId = getVerificationMethodIdOrDefault(options)
+      val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+      val verificationJwk = keyManager.getPublicKey(alias)
+      Pair(
+        PublicKey(
+          id = verificationMethodId,
+          type = "JsonWebKey2020",
+          publicKeyJwk = verificationJwk,
+          purposes = listOf(PublicKeyPurpose.AUTHENTICATION),
+        ),
+        alias
+      )
+    } else {
+      Pair(options.verificationPublicKey!!, null)
+    }
 
   private fun validateVerificationMethodId(id: String) {
     require(isBase64UrlString(id)) { "verification method id \"$id\" is not base 64 url charset" }
@@ -416,7 +453,7 @@ public sealed class DidIonManager(
   }
 
   internal fun createRecoverOperation(keyManager: KeyManager, options: RecoverDidIonOptions):
-    Pair<SidetreeRecoverOperation, String> {
+    Pair<SidetreeRecoverOperation, KeyAliases> {
     val recoveryPublicKey = keyManager.getPublicKey(options.recoveryKeyAlias)
     val reveal = recoveryPublicKey.reveal()
 
@@ -428,8 +465,10 @@ public sealed class DidIonManager(
     val nextUpdatePublicKey = keyManager.getPublicKey(nextUpdateKeyAlias)
     val nextUpdateCommitment = nextUpdatePublicKey.commitment()
 
+    val (verificationPublicKey, verificationKeyAlias) = getVerificationPublicKeyOrDefault(options, keyManager)
+
     val delta = Delta(
-      patches = options.toPatches(),
+      patches = options.toPatches(verificationPublicKey),
       updateCommitment = nextUpdateCommitment
     )
     val deltaHash = deltaHash(delta)
@@ -442,7 +481,7 @@ public sealed class DidIonManager(
 
     val jwsObject = sign(dataToBeSigned, keyManager, options.recoveryKeyAlias)
 
-    val did = DID.fromString(options.didString)
+    val did = DID.fromString(options.did)
     return Pair(
       SidetreeRecoverOperation(
         type = "recover",
@@ -451,9 +490,58 @@ public sealed class DidIonManager(
         delta = delta,
         signedData = jwsObject.serialize(),
       ),
-      nextUpdateKeyAlias
+      KeyAliases(
+        updateKeyAlias = nextUpdateKeyAlias,
+        verificationKeyAlias = verificationKeyAlias,
+        recoveryKeyAlias = nextRecoveryKeyAlias,
+      )
+    )
+  }
+
+  internal fun createDeactivateOperation(
+    keyManager: KeyManager,
+    options: DeactivateDidIonOptions): SidetreeDeactivateOperation {
+    val recoveryPublicKey = keyManager.getPublicKey(options.recoveryKeyAlias)
+    val reveal = recoveryPublicKey.reveal()
+
+    val did = DID.fromString(options.did)
+
+    val dataToBeSigned = DeactivateUpdateSignedData(
+      didSuffix = did.methodSpecificId,
+      recoveryKey = recoveryPublicKey,
     )
 
+    val jwsObject = sign(dataToBeSigned, keyManager, options.recoveryKeyAlias)
+
+    return SidetreeDeactivateOperation(
+      type = "deactivate",
+      didSuffix = did.methodSpecificId,
+      revealValue = reveal,
+      signedData = jwsObject.serialize(),
+    )
+  }
+
+  /**
+   * Recovers an ION did with the given [options]. The `recoveryKeyAlias` value must be available in the [keyManager].
+   */
+  public fun recover(keyManager: KeyManager, opts: RecoverDidIonOptions): RecoverResult {
+    val (recoverOp, keyAliases) = createRecoverOperation(keyManager, opts)
+
+    val response: HttpResponse = runBlocking {
+      client.post(operationsEndpoint) {
+        contentType(ContentType.Application.Json)
+        setBody(recoverOp)
+      }
+    }
+
+    val opBody = runBlocking {
+      response.bodyAsText()
+    }
+    return RecoverResult(
+      keyAliases = keyAliases,
+      recoverOperation = recoverOp,
+      operationsResponse = opBody,
+    )
   }
 
 
@@ -461,6 +549,19 @@ public sealed class DidIonManager(
    * Default companion object for creating a [DidIonManager] with a default configuration.
    */
   public companion object Default : DidIonManager(DidIonConfiguration())
+}
+
+/**
+ * All the data associated with the [recover] call. Useful for advanced, and debugging, purposes.
+ */
+public class RecoverResult(
+  public val keyAliases: KeyAliases,
+  public val recoverOperation: SidetreeRecoverOperation,
+  public val operationsResponse: String)
+
+private interface VerificationPublicKeyOption {
+  val verificationPublicKey: PublicKey?
+  val verificationMethodId: String?
 }
 
 private fun JWK.commitment(): Commitment {
@@ -493,6 +594,7 @@ private fun JWK.reveal(): Reveal {
   val mh = Multihash.sum(Multicodec.SHA2_256, canonicalized).getOrThrow()
   return Reveal(mh.bytes())
 }
+
 /**
  * Metadata related to the update of an ion DID.
  */
@@ -519,9 +621,9 @@ public class ResolutionException(msg: String) : RuntimeException(msg)
  * Container for the key aliases for an ION did.
  */
 public data class KeyAliases(
-  public val updateKeyAlias: String,
-  public val verificationKeyAlias: String,
-  public val recoveryKeyAlias: String)
+  public val updateKeyAlias: String?,
+  public val verificationKeyAlias: String?,
+  public val recoveryKeyAlias: String?)
 
 /**
  * Options available when creating an ion did.
@@ -533,11 +635,11 @@ public data class KeyAliases(
  * must only use characters from the Base64URL character set.
  */
 public class CreateDidIonOptions(
-  public val verificationPublicKey: PublicKey? = null,
+  public override val verificationPublicKey: PublicKey? = null,
   public val updatePublicJwk: JWK? = null,
   public val recoveryPublicJwk: JWK? = null,
-  public val verificationMethodId: String? = null,
-) : CreateDidOptions
+  public override val verificationMethodId: String? = null,
+) : CreateDidOptions, VerificationPublicKeyOption
 
 /**
  * Metadata related to the creation of a DID (Decentralized Identifier) on the Sidetree protocol.

--- a/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
@@ -196,6 +196,17 @@ public data class SidetreeUpdateOperation(
 )
 
 /**
+ * Sidetree recover operation as defined in https://identity.foundation/sidetree/api/#recover
+ */
+public data class SidetreeRecoverOperation(
+  public val type: String,
+  public val didSuffix: String,
+  public val revealValue: String,
+  public val delta: Delta,
+  public val signedData: String,
+)
+
+/**
  * Update operation signed data object as defined in https://identity.foundation/sidetree/spec/#update-signed-data-object
  */
 public data class UpdateOperationSignedData(
@@ -222,3 +233,16 @@ public class MetadataMethod(
   public val recoveryCommitment: String,
   public val updateCommitment: String,
 )
+
+/**
+ * Recovery operation signed data object as defined in https://identity.foundation/sidetree/spec/#recovery-signed-data-object
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RecoveryUpdateSignedData(
+  public val recoveryCommitment: Commitment,
+
+  @JsonSerialize(using = JacksonJWK.Serializer::class)
+  @JsonDeserialize(using = JacksonJWK.Deserializer::class)
+  public val recoveryKey: JWK,
+  public val deltaHash: String,
+  public val anchorOrigin: String? = null)

--- a/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
@@ -294,3 +294,23 @@ public class RecoveryUpdateSignedData(
   public val recoveryKey: JWK,
   public val deltaHash: String,
   public val anchorOrigin: String? = null)
+
+
+/**
+ * Deactivate operation signed data object as defined in https://identity.foundation/sidetree/spec/#deactivate-signed-data-object
+ */
+public class DeactivateUpdateSignedData(
+  public val didSuffix: String,
+
+  @JsonSerialize(using = JacksonJwk.Serializer::class)
+  @JsonDeserialize(using = JacksonJwk.Deserializer::class)
+  public val recoveryKey: JWK)
+
+/**
+ * Sidetree recover operation as defined in https://identity.foundation/sidetree/api/#deactivate
+ */
+public class SidetreeDeactivateOperation(
+  public val type: String,
+  public val didSuffix: String,
+  public val revealValue: Reveal,
+  public val signedData: String)

--- a/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
@@ -249,7 +249,7 @@ public data class SidetreeUpdateOperation(
 public data class SidetreeRecoverOperation(
   public val type: String,
   public val didSuffix: String,
-  public val revealValue: String,
+  public val revealValue: Reveal,
   public val delta: Delta,
   public val signedData: String,
 )

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
+import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.ion.model.PublicKey
 import web5.sdk.dids.ion.model.PublicKeyPurpose
@@ -41,6 +42,19 @@ class DidIonTest {
     val did = DidIonManager.create(InMemoryKeyManager())
     assertContains(did.uri, "did:ion:")
     assertTrue(did.creationMetadata!!.longFormDid.startsWith(did.uri))
+  }
+
+  @Test
+  @Ignore("For demonstration purposes only - relies on network and AWS configuration")
+  fun `create with AWS key manager`() {
+    val keyManager = AwsKeyManager()
+    val ionManager = DidIonManager
+    val didsCreated = buildList {
+      repeat(32) {
+        add(ionManager.create(keyManager))
+      }
+    }
+    didsCreated.forEach { println(it.uri) }
   }
 
   @Test

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -236,12 +236,12 @@ class DidIonTest {
     )
 
     assertEquals("EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg", recoverOperation.didSuffix)
-    assertEquals("EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ", recoverOperation.revealValue.toBase64Url());
-    assertEquals("recover", recoverOperation.type);
+    assertEquals("EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ", recoverOperation.revealValue.toBase64Url())
+    assertEquals("recover", recoverOperation.type)
     assertEquals(
       "EiBJGXo0XUiqZQy0r-fQUHKS3RRVXw5nwUpqGVXEGuTs-g",
       recoverOperation.delta.updateCommitment.toBase64Url()
-    );
+    )
     assertEquals(
       "eyJhbGciOiJFUzI1NksifQ.eyJyZWNvdmVyeUNvbW1pdG1lbnQiOiJFaURLSWt3cU82OUlQRzNwT2xIa2RiODZuWXQwYU54U" +
         "0hadTJyLWJoRXpuamRBIiwicmVjb3ZlcnlLZXkiOnsia3R5IjoiRUMiLCJjcnYiOiJzZWNwMjU2azEiLCJ4IjoibklxbFJDeDBleUJT" +
@@ -249,7 +249,7 @@ class DidIonTest {
         "4RjdrIn0sImRlbHRhSGFzaCI6IkVpQm9HNlFtamlTSm5ON2phaldnaV9vZDhjR3dYSm9Nc2RlWGlWWTc3NXZ2SkEifQ.58n6Fel9DmR" +
         "AXxwcJMUwYaUhmj5kigKMNrGjr7eJaJcjOmjvwlKLSjiovWiYrb9yjkfMAjpgbAdU_2EDI1_lZw",
       recoverOperation.signedData
-    );
+    )
     assertEquals(1, recoverOperation.delta.patches.count())
     assertEquals(nextUpdateKeyId, keyAliases.updateKeyAlias)
     assertEquals(nextRecoveryKeyId, keyAliases.recoveryKeyAlias)

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -291,7 +291,9 @@ class DidIonTest {
     val recoveryKey = readKey("src/test/resources/jwkEs256k1Private.json")
     val recoveryKeyAlias = keyManager.import(recoveryKey)
 
-    val result = DidIonManager.createDeactivateOperation(
+    val deactivateResult = DidIonManager{
+      engine = mockEngine()
+    }.deactivate(
       keyManager,
       DeactivateDidIonOptions(
         did = "did:ion:EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg",
@@ -299,15 +301,19 @@ class DidIonTest {
       )
     )
 
-    assertEquals("EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg", result.didSuffix)
-    assertEquals("deactivate", result.type)
-    assertEquals("EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ", result.revealValue.toBase64Url())
+    val deactivateOperation = deactivateResult.deactivateOperation
+    assertEquals("EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg", deactivateOperation.didSuffix)
+    assertEquals("deactivate", deactivateOperation.type)
+    assertEquals(
+      "EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ",
+      deactivateOperation.revealValue.toBase64Url()
+    )
     assertEquals(
       "eyJhbGciOiJFUzI1NksifQ.eyJkaWRTdWZmaXgiOiJFaUR5T1FiYlpBYTNhaVJ6ZUNrVjdMT3gzU0VSampIOTNFWG9JTTNVb040b1" +
         "dnIiwicmVjb3ZlcnlLZXkiOnsia3R5IjoiRUMiLCJjcnYiOiJzZWNwMjU2azEiLCJ4IjoibklxbFJDeDBleUJTWGNRbnFEcFJlU3Y0enVXaH" +
         "dDUldzc29jOUxfbmo2QSIsInkiOiJpRzI5Vks2bDJVNXNLQlpVU0plUHZ5RnVzWGdTbEsyZERGbFdhQ004RjdrIn19.uLgnDBmmFzST4VTmd" +
         "JcmFKVicF0kQaBqEnRQLbqJydgIg_2oreihCA5sBBIUBlSXwvnA9xdK97ksJGmPQ7asPQ",
-      result.signedData
+      deactivateOperation.signedData
     )
   }
 

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -239,9 +239,12 @@ class DidIonTest {
     )
 
     assertEquals("EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg", recoverOperation.didSuffix)
-    assertEquals("EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ", recoverOperation.revealValue);
+    assertEquals("EiAJ-97Is59is6FKAProwDo870nmwCeP8n5nRRFwPpUZVQ", recoverOperation.revealValue.toBase64Url());
     assertEquals("recover", recoverOperation.type);
-    assertEquals("EiBJGXo0XUiqZQy0r-fQUHKS3RRVXw5nwUpqGVXEGuTs-g", recoverOperation.delta.updateCommitment);
+    assertEquals(
+      "EiBJGXo0XUiqZQy0r-fQUHKS3RRVXw5nwUpqGVXEGuTs-g",
+      recoverOperation.delta.updateCommitment.toBase64Url()
+    );
     val jws = JWSObject.parse(recoverOperation.signedData)
     assertDoesNotThrow {
       Crypto.verify(recoveryKey.toPublicJWK(), jws.signingInput, jws.signature.decode(), jws.header.algorithm)
@@ -253,7 +256,7 @@ class DidIonTest {
         "4RjdrIn0sImRlbHRhSGFzaCI6IkVpQm9HNlFtamlTSm5ON2phaldnaV9vZDhjR3dYSm9Nc2RlWGlWWTc3NXZ2SkEifQ",
       jws.signingInput.decodeToString()
     );
-    assertEquals(1, recoverOperation.delta.patches.size)
+    assertEquals(1, recoverOperation.delta.patches.count())
     assertEquals(nextUpdateKeyId, updateKeyAlias)
   }
 

--- a/dids/src/test/resources/jwkEs256k3Public.json
+++ b/dids/src/test/resources/jwkEs256k3Public.json
@@ -1,0 +1,6 @@
+{
+  "kty": "EC",
+  "crv": "secp256k1",
+  "x": "z2f-UmRilQ2jVzYo-lYtn2TeBWWC284MlUaGcjSdmJ4",
+  "y": "KAuEa77izdMyjdnR6r1CZL1g4bixlsMfbXifkjAlBg8"
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -60,6 +60,49 @@ val did = DidIonManager.create(keyManager, opts)
 ### Resolve an ION did
 
 ```kotlin
-val ionManager = DidIonManager{}
+val ionManager = DidIonManager
 val didResolutionResult = ionManager.resolve("did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w")
 ```
+
+### Recover an ION did
+
+Any sidetree based DID, including ION, supports a [recover operation](https://identity.foundation/sidetree/spec/#recover).
+This type of operation is useful when the update keys of your DID have been compromised. 
+
+```kotlin
+// We create the DID first. 
+val ionManager = DidIonManager
+val keyManager = InMemoryKeyManager()
+val did = ionManager.create(keyManager)
+val recoveryKeyAlias = did.creationMetadata!!.keyAliases.verificationKeyAlias
+
+// Imagine that your update key was compromised, so you need to recover your DID.
+val opts = RecoverDidIonOptions(
+  did = did.uri,
+  recoveryKeyAlias = recoveryKeyAlias,  
+)
+val recoverResult = ionManager.recover(keyManager, opts)
+```
+
+> [!NOTE]
+> The `keyManager` MUST contain the recovery private key.
+
+### Deactivate an ION did
+
+```kotlin
+// We create the DID first. 
+val ionManager = DidIonManager
+val keyManager = InMemoryKeyManager()
+val did = ionManager.create(keyManager)
+val recoveryKeyAlias = did.creationMetadata!!.keyAliases.verificationKeyAlias
+
+// You want to permanently disable the DID, rendering it useless.
+val opts = DeactivateDidIonOptions(
+  did = did.uri,
+  recoveryKeyAlias = recoveryKeyAlias,
+)
+val deactivateResult = ionManager.deactivate(keyManager, opts)
+```
+
+> [!NOTE]
+> The `keyManager` MUST contain the recovery private key.


### PR DESCRIPTION
# Overview
This PR introduces `recover` and `deactivate` for ion DIDs. Fixes #3 and #2.

# Description
Some notes in this PR:
* The `recover` operation API design was so that it matches the `create` API.
* Operations now return an `Ion<operation_type>Result` object. This makes working with DIDs easier.
* Examples were added in the `examples.md` readme.
* Small fixes to ensure the issuance also works with an ION did that was created with an AWS key manager.
* The changes in #87 are merged, as they're needed for tests to pass.
* It's built on top of #77 

# How Has This Been Tested?
Unit tests similar to the ones in the ion-sdk were added.

## References
* https://identity.foundation/sidetree/api/#recover
* https://identity.foundation/sidetree/api/#deactivate