### PR TITLE
Support adding services on DID creation

### DIFF
--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -33,6 +33,7 @@ import web5.sdk.dids.ion.model.OperationSuffixDataObject
 import web5.sdk.dids.ion.model.PublicKey
 import web5.sdk.dids.ion.model.PublicKeyPurpose
 import web5.sdk.dids.ion.model.ReplaceAction
+import web5.sdk.dids.ion.model.Service
 import web5.sdk.dids.ion.model.SidetreeCreateOperation
 import java.util.UUID
 
@@ -223,7 +224,16 @@ public sealed class DidIonManager(
     } else {
       options.verificationPublicKey
     }
-    val patches = listOf(ReplaceAction(Document(listOf(verificationPublicKey))))
+
+    val services = options?.servicesToAdd?.toList() ?: emptyList()
+    val patches = listOf(
+      ReplaceAction(
+        Document(
+          publicKeys = listOf(verificationPublicKey),
+          services = services,
+        )
+      )
+    )
     val createOperationDelta = Delta(
       patches = patches,
       updateCommitment = publicKeyCommitment
@@ -331,12 +341,14 @@ public data class KeyAliases(
  * @param recoveryPublicJwk When provided, will be used to create the recovery key commitment.
  * @param verificationMethodId When provided, will be used as the verification method id. Cannot be over 50 chars and
  * must only use characters from the Base64URL character set.
+ * @param servicesToAdd When provided, the services will be added to the DID document.
  */
 public class CreateDidIonOptions(
-  public val verificationPublicKey: PublicKey? = null,
   public val updatePublicJwk: JWK? = null,
   public val recoveryPublicJwk: JWK? = null,
+  public val verificationPublicKey: PublicKey? = null,
   public val verificationMethodId: String? = null,
+  public val servicesToAdd: Iterable<Service>? = null,
 ) : CreateDidOptions
 
 /**

--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -269,10 +269,8 @@ public sealed class DidIonManager(
     )
   }
 
-  private fun validateServices(services: List<Service>) {
-    services.forEach {
-      validateService(it)
-    }
+  private fun validateServices(services: List<Service>) = services.forEach {
+    validateService(it)
   }
 
   private fun validateService(service: Service) {

--- a/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/ion/model/Models.kt
@@ -21,6 +21,7 @@ import com.nimbusds.jose.jwk.JWK
  * @property publicKeys List of public keys.
  * @property services List of services.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public data class Document(
   val publicKeys: List<PublicKey> = emptyList(),
   val services: List<Service> = emptyList()

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.assertThrows
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.ion.model.PublicKey
 import web5.sdk.dids.ion.model.PublicKeyPurpose
+import web5.sdk.dids.ion.model.Service
 import web5.sdk.dids.ion.model.SidetreeCreateOperation
 import java.io.File
 import kotlin.test.Ignore
@@ -75,6 +76,13 @@ class DidIonTest {
         type = "JsonWebKey2020",
         publicKeyJwk = verificationKey,
         purposes = listOf(PublicKeyPurpose.AUTHENTICATION),
+      ),
+      servicesToAdd = listOf(
+        Service(
+          id = "#dwn",
+          type = "DWN",
+          serviceEndpoint = "http://hub.my-personal-server.com",
+        )
       ),
       updatePublicJwk = updateKey,
       recoveryPublicJwk = recoveryKey

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -48,6 +48,53 @@ class DidIonTest {
   }
 
   @Test
+  fun `invalid services throw exception`() {
+    class TestCase(
+      val service: Service,
+      val expectedContains: String
+    )
+
+    val testCases = listOf(
+      TestCase(
+        Service(
+          id = "#dwn",
+          type = "DWN",
+          serviceEndpoint = "http://my.service.com",
+        ),
+        "is not base 64 url charse",
+      ),
+      TestCase(
+        Service(
+          id = "dwn",
+          type = "really really really really really really really really long type",
+          serviceEndpoint = "http://my.service.com",
+        ),
+        "service type \"really really really really really really really really long type\" exceeds" +
+          " max allowed length of 30",
+      ),
+      TestCase(
+        Service(
+          id = "dwn",
+          type = "DWN",
+          serviceEndpoint = "an invalid uri",
+        ),
+        "service endpoint is not a valid URI",
+      )
+    )
+    for (testCase in testCases) {
+      val exception = assertThrows<IllegalArgumentException> {
+        DidIonManager.create(
+          InMemoryKeyManager(),
+          CreateDidIonOptions(
+            servicesToAdd = listOf(testCase.service)
+          )
+        )
+      }
+      assertContains(exception.message!!, testCase.expectedContains)
+    }
+  }
+
+  @Test
   fun `very long verificationMethodId throws exception`() {
     val exception = assertThrows<IllegalArgumentException> {
       DidIonManager.create(
@@ -79,7 +126,7 @@ class DidIonTest {
       ),
       servicesToAdd = listOf(
         Service(
-          id = "#dwn",
+          id = "dwn",
           type = "DWN",
           serviceEndpoint = "http://hub.my-personal-server.com",
         )


### PR DESCRIPTION
# Overview
Added an option for adding `services` upon DID ION creation. 

# Description
This PR:
* Includes validation of the fields as it exists in https://github.com/decentralized-identity/ion-sdk/blob/main/lib/IonRequest.ts#L319.
* Adds tests.

# How Has This Been Tested?
Unit
