### PR TITLE
Default ion creation sets assertion method

### DIFF
--- a/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidIonManager.kt
@@ -222,7 +222,7 @@ public sealed class DidIonManager(
         id = verificationMethodId,
         type = "JsonWebKey2020",
         publicKeyJwk = verificationJwk,
-        purposes = listOf(PublicKeyPurpose.AUTHENTICATION),
+        purposes = listOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD),
       )
     } else {
       options.verificationPublicKey

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -27,10 +27,9 @@ import kotlin.test.assertTrue
 class DidIonTest {
 
   @Test
-//  @Ignore("For demonstration purposes only - this makes a network call")
+  @Ignore("For demonstration purposes only - this makes a network call")
   fun createWithDefault() {
     val did = DidIonManager.create(InMemoryKeyManager())
-    val resolution = DidResolvers.resolve(did.uri)
     assertContains(did.uri, "did:ion:")
     assertTrue(did.creationMetadata!!.longFormDid.startsWith(did.uri))
   }

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -27,9 +27,10 @@ import kotlin.test.assertTrue
 class DidIonTest {
 
   @Test
-  @Ignore("For demonstration purposes only - this makes a network call")
+//  @Ignore("For demonstration purposes only - this makes a network call")
   fun createWithDefault() {
     val did = DidIonManager.create(InMemoryKeyManager())
+    val resolution = DidResolvers.resolve(did.uri)
     assertContains(did.uri, "did:ion:")
     assertTrue(did.creationMetadata!!.longFormDid.startsWith(did.uri))
   }
@@ -137,6 +138,7 @@ class DidIonTest {
     val did = manager.create(keyManager, opts)
     assertContains(did.uri, "did:ion:")
     assertContains(did.creationMetadata!!.longFormDid, did.creationMetadata!!.shortFormDid)
+
   }
 
   private fun readKey(pathname: String): JWK {

--- a/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidIonTest.kt
@@ -137,7 +137,6 @@ class DidIonTest {
     val did = manager.create(keyManager, opts)
     assertContains(did.uri, "did:ion:")
     assertContains(did.creationMetadata!!.longFormDid, did.creationMetadata!!.shortFormDid)
-
   }
 
   private fun readKey(pathname: String): JWK {

--- a/dids/src/test/kotlin/web5/sdk/dids/DidResolversTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidResolversTest.kt
@@ -1,6 +1,6 @@
 package web5.sdk.dids
 
-import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.InMemoryKeyManager
 
@@ -10,5 +10,13 @@ class DidResolversTest {
   @Test
   fun `it works`() {
     DidResolvers.resolve("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp", null)
+  }
+
+  @Test
+  fun `resolving a default ion did contains assertion method`() {
+    val ionDid = DidIonManager.create(InMemoryKeyManager())
+
+    val resolutionResult= DidResolvers.resolve(ionDid.uri)
+    assertNotNull(resolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced)
   }
 }


### PR DESCRIPTION
# Overview
Default did ion sets assertion method used in crypto verification operations

# How Has This Been Tested?
_Describe the tests that you ran to verify your changes. Provide instructions for verification._

- [x] Tested via resolver
