### PR TITLE
version bump third party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
+          distribution: 'corretto'
           java-version: 11
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
-      - uses: actions/cache@v2
+          java-version: 11
+      - uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}


### PR DESCRIPTION
<img width="1278" alt="image" src="https://github.com/TBD54566975/web5-kt/assets/4887440/e4862454-2e82-4bfb-8665-35a24ca47f7a">


Some of our actions use a version of node that's no longer supported. GitHub is going to force these actions to run on a newer version of node. Took a quick look at the ones flagged in the warning and noticed that there were newer versions. figured we might as well update them directly