### PR TITLE
Implement JWK with spec tests.

### DIFF
--- a/dids/module.md
+++ b/dids/module.md
@@ -6,6 +6,8 @@
 
 ## Creation
 
+### Creating a DID Key
+
 ```kt
 package example
 
@@ -14,6 +16,18 @@ import web5.sdk.dids.methods.key.DidKey
 
 val keyManager = InMemoryKeyManager()
 val did = DidKey.create(keyManager)
+```
+
+### Creating a DID Jwk
+
+```kt
+package example
+
+import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.methods.jwk.DidJwk
+
+val keyManager = InMemoryKeyManager()
+val did = DidJwk.create(keyManager)
 ```
 
 ## Export / Import

--- a/dids/src/main/kotlin/web5/sdk/dids/DidResolvers.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidResolvers.kt
@@ -2,6 +2,7 @@ package web5.sdk.dids
 
 import foundation.identity.did.DID
 import web5.sdk.dids.methods.ion.DidIon
+import web5.sdk.dids.methods.jwk.DidJwk
 import web5.sdk.dids.methods.key.DidKey
 
 /**
@@ -22,6 +23,7 @@ public object DidResolvers {
   // A mutable map to store method-specific DID resolvers.
   private val methodResolvers = mutableMapOf<String, DidResolver>(
     DidKey.methodName to DidKey.Companion::resolve,
+    DidJwk.methodName to DidJwk.Companion::resolve,
     DidIon.methodName to DidIon.Default::resolve
   )
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -1,0 +1,165 @@
+package web5.sdk.dids.methods.jwk
+
+import com.nimbusds.jose.Algorithm
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.KeyUse
+import foundation.identity.did.DID
+import foundation.identity.did.DIDDocument
+import foundation.identity.did.VerificationMethod
+import web5.sdk.common.Convert
+import web5.sdk.common.EncodingFormat
+import web5.sdk.crypto.KeyManager
+import web5.sdk.dids.CreateDidOptions
+import web5.sdk.dids.Did
+import web5.sdk.dids.DidMethod
+import web5.sdk.dids.DidResolutionResult
+import web5.sdk.dids.ResolveDidOptions
+import java.net.URI
+
+/**
+ * Specifies options for creating a new "did:jwk" Decentralized Identifier (DID).
+ *
+ * @property algorithm Specifies the algorithm to be used for key creation.
+ *                     Defaults to ES256K (Elliptic Curve Digital Signature Algorithm with SHA-256 and secp256k1 curve).
+ * @property curve Specifies the elliptic curve to be used with the algorithm.
+ *                 Optional and can be null if the algorithm does not require an explicit curve specification.
+ *
+ * @constructor Creates an instance of [CreateDidJwkOptions] with the provided [algorithm] and [curve].
+ *
+ * ### Usage Example:
+ * ```
+ * val options = CreateDidJwkOptions(algorithm = JWSAlgorithm.ES256K, curve = null)
+ * val didJwk = DidJwk.create(keyManager, options)
+ * ```
+ */
+public class CreateDidJwkOptions(
+  public val algorithm: Algorithm = JWSAlgorithm.ES256K,
+  public val curve: Curve? = null
+) : CreateDidOptions
+
+/**
+ * Provides a specific implementation for creating and resolving "did:jwk" method Decentralized Identifiers (DIDs).
+ *
+ * A "did:jwk" DID is a special type of DID that is formulated directly from a single public key. It's utilized
+ * in scenarios where it's beneficial for verifiable credentials, capabilities, or other assertions about a subject
+ * to be self-verifiable by third parties. This eradicates the necessity for a separate blockchain or ledger.
+ * Further specifics and technical details are outlined in [the DID Jwk Spec](https://example.org/did-method-jwk/).
+ *
+ * @property uri The URI of the "did:jwk" which conforms to the DID standard.
+ * @property keyManager A [KeyManager] instance utilized to manage the cryptographic keys associated with the DID.
+ *
+ * @constructor Initializes a new instance of [DidJwk] with the provided [uri] and [keyManager].
+ *
+ * ### Usage Example:
+ * ```kotlin
+ * val keyManager = InMemoryKeyManager()
+ * val did = DidJwk("did:jwk:example", keyManager)
+ * ```
+ */
+public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
+  /**
+   * Resolves the current instance's [uri] to a [DidResolutionResult], which contains the DID Document
+   * and possible related metadata.
+   *
+   * @return A [DidResolutionResult] instance containing the DID Document and related context.
+   *
+   * @throws IllegalArgumentException if the provided DID does not conform to the "did:jwk" method.
+   */
+  public fun resolve(): DidResolutionResult {
+    return resolve(this.uri)
+  }
+
+  public companion object : DidMethod<DidJwk, CreateDidJwkOptions> {
+    override val methodName: String = "jwk"
+
+    /**
+     * Creates a new "did:jwk" DID, derived from a public key, and stores the associated private key in the
+     * provided [KeyManager].
+     *
+     * The method-specific identifier of a "did:jwk" DID is a base64url encoded json web key serialized as a UTF-8
+     * string.
+     *
+     * **Note**: Defaults to ES256K if no options are provided
+     *
+     * @param keyManager A [KeyManager] instance where the new key will be stored.
+     * @param options Optional parameters ([CreateDidJwkOptions]) to specify algorithm and curve during key creation.
+     * @return A [DidJwk] instance representing the newly created "did:jwk" DID.
+     *
+     * @throws UnsupportedOperationException if the specified curve is not supported.
+     */
+    override fun create(keyManager: KeyManager, options: CreateDidJwkOptions?): DidJwk {
+      val opts = options ?: CreateDidJwkOptions()
+
+      val keyAlias = keyManager.generatePrivateKey(opts.algorithm, opts.curve)
+      val publicKey = keyManager.getPublicKey(keyAlias)
+
+      val base64Encoded = Convert(publicKey.toJSONString()).toBase64Url(padding = false)
+
+      val did = "did:jwk:$base64Encoded"
+
+      return DidJwk(did, keyManager)
+    }
+
+    /**
+     * Resolves a "did:jwk" DID into a [DidResolutionResult], which contains the DID Document and possible related metadata.
+     *
+     * This implementation primarily constructs a DID Document with a single verification method derived
+     * from the DID's method-specific identifier (the public key).
+     *
+     * @param did The "did:jwk" DID that needs to be resolved.
+     * @return A [DidResolutionResult] instance containing the DID Document and related context.
+     *
+     * @throws IllegalArgumentException if the provided DID does not conform to the "did:jwk" method.
+     */
+    override fun resolve(did: String, options: ResolveDidOptions?): DidResolutionResult {
+      val parsedDid = DID.fromString(did)
+
+      require(parsedDid.methodName == methodName) { throw IllegalArgumentException("expected did:jwk") }
+
+      val id = parsedDid.methodSpecificId
+      val decodedKey = Convert(id, EncodingFormat.Base64Url).toStr()
+      val publicKeyJwk = JWK.parse(decodedKey)
+
+      require(!publicKeyJwk.isPrivate) {
+        throw IllegalArgumentException("decoded jwk value cannot be a private key")
+      }
+
+      val verificationMethodId = URI.create("$did#0")
+      val verificationMethod = VerificationMethod.builder()
+        .id(verificationMethodId)
+        .publicKeyJwk(publicKeyJwk.toJSONObject())
+        .controller(URI(did))
+        .type("JsonWebKey2020")
+        .build()
+
+      val verificationMethodRef = VerificationMethod.builder()
+        .id(verificationMethodId)
+        .build()
+
+      val didDocumentBuilder = DIDDocument.builder()
+        .contexts(
+          mutableListOf(
+            URI.create("https://w3id.org/security/suites/jws-2020/v1")
+          )
+        )
+        .id(URI(did))
+        .verificationMethod(verificationMethod)
+
+      if (publicKeyJwk.keyUse != KeyUse.ENCRYPTION) {
+        didDocumentBuilder
+          .assertionMethodVerificationMethod(verificationMethodRef)
+          .authenticationVerificationMethod(verificationMethodRef)
+          .capabilityDelegationVerificationMethods(listOf(verificationMethodRef))
+          .capabilityInvocationVerificationMethod(verificationMethodRef)
+      }
+      if (publicKeyJwk.keyUse != KeyUse.SIGNATURE) {
+        didDocumentBuilder.keyAgreementVerificationMethod(verificationMethodRef)
+      }
+      val didDocument = didDocumentBuilder.build()
+
+      return DidResolutionResult(didDocument = didDocument, context = "https://w3id.org/did-resolution/v1")
+    }
+  }
+}

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
@@ -1,0 +1,82 @@
+package web5.sdk.dids.methods.jwk
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.JWK
+import org.erdtman.jcs.JsonCanonicalizer
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import web5.sdk.common.Convert
+import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.DidResolvers
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DidJwkTest {
+  @Nested
+  inner class CreateTest {
+    @Test
+    fun `creates an ES256K key when no options are passed`() {
+      val manager = InMemoryKeyManager()
+      val did = DidJwk.create(manager)
+
+      val didResolutionResult = DidResolvers.resolve(did.uri)
+      val verificationMethod = didResolutionResult.didDocument.allVerificationMethods[0]
+
+      assertNotNull(verificationMethod)
+
+      val jwk = JWK.parse(verificationMethod.publicKeyJwk)
+      val keyAlias = did.keyManager.getDeterministicAlias(jwk)
+      val publicKey = did.keyManager.getPublicKey(keyAlias)
+
+      assertEquals(JWSAlgorithm.ES256K, publicKey.algorithm)
+    }
+  }
+
+  @Nested
+  inner class ResolveTest {
+    @Test
+    fun `private key throws exception`() {
+      val manager = InMemoryKeyManager()
+      manager.generatePrivateKey(JWSAlgorithm.ES256K)
+      val privateJwk = JWK.parse(manager.export().first())
+      val encodedPrivateJwk = Convert(privateJwk.toJSONString()).toBase64Url(padding = false)
+
+      val did = "did:jwk:$encodedPrivateJwk"
+      assertThrows<IllegalArgumentException>("decoded jwk value cannot be a private key") { DidJwk.resolve(did) }
+    }
+
+    @Test
+    fun `test vector 1`() {
+      // test vector taken from: https://github.com/quartzjer/did-jwk/blob/main/spec.md#p-256
+      @Suppress("MaxLineLength")
+      val did =
+        "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9"
+      val result = DidJwk.resolve(did)
+      assertNotNull(result)
+
+      val didDocument = result.didDocument
+      assertNotNull(didDocument)
+
+      val expectedJson = File("src/test/resources/did_jwk_p256_document.json").readText()
+      assertEquals(JsonCanonicalizer(expectedJson).encodedString, JsonCanonicalizer(didDocument.toJson()).encodedString)
+    }
+
+    @Test
+    fun `test vector 2`() {
+      // test vector taken from: https://github.com/quartzjer/did-jwk/blob/main/spec.md#x25519
+      @Suppress("MaxLineLength")
+      val did =
+        "did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9"
+      val result = DidJwk.resolve(did)
+      assertNotNull(result)
+
+      val didDocument = result.didDocument
+      assertNotNull(didDocument)
+
+      val expectedJson = File("src/test/resources/did_jwk_x25519_document.json").readText()
+      assertEquals(JsonCanonicalizer(expectedJson).encodedString, JsonCanonicalizer(didDocument.toJson()).encodedString)
+    }
+  }
+}

--- a/dids/src/test/resources/did_jwk_p256_document.json
+++ b/dids/src/test/resources/did_jwk_p256_document.json
@@ -1,0 +1,35 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9",
+  "verificationMethod": [
+    {
+      "id": "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0",
+      "type": "JsonWebKey2020",
+      "controller": "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9",
+      "publicKeyJwk": {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "acbIQiuMs3i8_uszEjJ2tpTtRM4EU3yz91PH6CdH2V0",
+        "y": "_KcyLj9vWMptnmKtm46GqDz8wf74I5LKgrl2GzH3nSE"
+      }
+    }
+  ],
+  "assertionMethod": [
+    "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0"
+  ],
+  "authentication": [
+    "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0"
+  ],
+  "capabilityInvocation": [
+    "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0"
+  ],
+  "capabilityDelegation": [
+    "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0"
+  ],
+  "keyAgreement": [
+    "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFjYklRaXVNczNpOF91c3pFakoydHBUdFJNNEVVM3l6OTFQSDZDZEgyVjAiLCJ5IjoiX0tjeUxqOXZXTXB0bm1LdG00NkdxRHo4d2Y3NEk1TEtncmwyR3pIM25TRSJ9#0"
+  ]
+}

--- a/dids/src/test/resources/did_jwk_x25519_document.json
+++ b/dids/src/test/resources/did_jwk_x25519_document.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9",
+  "verificationMethod": [
+    {
+      "id": "did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9#0",
+      "type": "JsonWebKey2020",
+      "controller": "did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "X25519",
+        "use": "enc",
+        "x": "3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08"
+      }
+    }
+  ],
+  "keyAgreement": [
+    "did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJYMjU1MTkiLCJ1c2UiOiJlbmMiLCJ4IjoiM3A3YmZYdDl3YlRUVzJIQzdPUTFOei1EUThoYmVHZE5yZngtRkctSUswOCJ9#0"
+  ]
+}


### PR DESCRIPTION
# Overview
This PR implements `did:jwk` creation and resolution. It closes #129 

# Description
The API is the same as all other did methods. In particular, it's the same as `DidKey`. Documentation has also been updated. 

# How Has This Been Tested?
Implemented the examples from the spec. There are additional test vectors in a json implementation in https://github.com/OR13/did-jwk/blob/main/src/signatures-test-vectors.json, but they currently don't match the specification. https://github.com/OR13/did-jwk/issues/4 has more details. 

## References
* https://github.com/quartzjer/did-jwk/blob/main/spec.md
