### PR TITLE
Make constructors internal/private and introduce a `load` method

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -23,6 +23,7 @@ import web5.sdk.common.Convert
 import web5.sdk.crypto.Crypto
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidResolvers
+import web5.sdk.dids.findAssertionMethodById
 import java.net.URI
 import java.security.SignatureException
 import java.util.Date
@@ -72,18 +73,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
    * ```
    */
   public fun sign(did: Did, assertionMethodId: String? = null): String {
-    val didResolutionResult = DidResolvers.resolve(did.uri)
-    val assertionMethods: List<VerificationMethod>? =
-      didResolutionResult.didDocument.assertionMethodVerificationMethodsDereferenced
-
-    require(!assertionMethods.isNullOrEmpty()) {
-      throw SignatureException("No assertion methods found in DID document")
-    }
-
-    val assertionMethod: VerificationMethod = when {
-      assertionMethodId != null -> assertionMethods.find { it.id.toString() == assertionMethodId }
-      else -> assertionMethods.firstOrNull()
-    } ?: throw SignatureException("assertion method $assertionMethodId not found")
+    val assertionMethod: VerificationMethod = did.findAssertionMethodById(assertionMethodId)
 
     // TODO: ensure that publicKeyJwk is not null
     val publicKeyJwk = JWK.parse(assertionMethod.publicKeyJwk)

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -16,7 +16,6 @@ import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
-import web5.sdk.dids.methods.ion.DidIonApi
 import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
 import web5.sdk.dids.methods.key.DidKey
 import java.security.SignatureException
@@ -43,7 +42,7 @@ class VerifiableCredentialTest {
         "2aWNlcyI6W119fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNsaVVIbHBQQjE0VVpkVzk4S250aG8zV2YxRjQxOU83cFhSMGhPeFAzRkNnIn0" +
         "sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlEU2FMNHZVNElzNmxDalp4YVp6Zl9lWFFMU3V5T3E5T0pNbVJHa2FFTzRCQSIsInJlY29" +
         "2ZXJ5Q29tbWl0bWVudCI6IkVpQzI0TFljVEdRN1JzaDdIRUl2TXQ0MGNGbmNhZGZReTdibDNoa3k0RkxUQ2cifX0"
-    val issuerDid = DidIon(didUri, keyManager, didIonApi = DidIonApi {})
+    val issuerDid = DidIon.load(didUri, keyManager)
     val holderDid = DidKey.create(keyManager)
 
     val vc = VerifiableCredential.create(

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -80,7 +80,11 @@ public class InMemoryKeyManager : KeyManager {
    * @throws IllegalArgumentException if the key is not known to the [KeyManager]
    */
   override fun getDeterministicAlias(publicKey: JWK): String {
-    return publicKey.keyID
+    val kid = publicKey.keyID ?: publicKey.computeThumbprint().toString()
+    require(keyStore.containsKey(kid)) {
+      "key with alias $kid not found"
+    }
+    return kid
   }
 
   private fun getPrivateKey(keyAlias: String) =
@@ -117,5 +121,5 @@ public class InMemoryKeyManager : KeyManager {
    *
    * @return A list of key representations in map format.
    */
-    public fun export(): List<Map<String, Any>> = keyStore.map { it.value.toJSONObject() }
+  public fun export(): List<Map<String, Any>> = keyStore.map { it.value.toJSONObject() }
 }

--- a/dids/module.md
+++ b/dids/module.md
@@ -73,7 +73,7 @@ fun main() {
   val keyManager = InMemoryKeyManager()
   keyManager.import(jsonKeySet)
 
-  val did = DidKey(uri = didUri, keyManager = keyManager)
+  val did = DidKey.load(did = didUri, keyManager = keyManager)
 }
 ```
 

--- a/dids/src/main/kotlin/web5/sdk/dids/DidWeb.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/DidWeb.kt
@@ -35,7 +35,7 @@ import kotlin.text.Charsets.UTF_8
  * val did = StatefulWebDid("did:web:tbd.website", keyManager)
  * ```
  */
-public class DidWeb(
+public class DidWeb internal constructor(
   uri: String,
   keyManager: KeyManager,
   private val didWebApi: DidWebApi
@@ -109,6 +109,11 @@ public sealed class DidWebApi(
     return DidResolutionResult(
       didDocument = mapper.readValue(body, DIDDocument::class.java),
     )
+  }
+
+  override fun load(did: String, keyManager: KeyManager): DidWeb {
+    validateKeyMaterialInsideKeyManager(did, keyManager)
+    return DidWeb(did, keyManager, this)
   }
 
   private fun getDocURL(didWebStr: String): String {

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -21,7 +21,13 @@ import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
-import web5.sdk.dids.*
+import web5.sdk.dids.CreateDidOptions
+import web5.sdk.dids.Did
+import web5.sdk.dids.DidMethod
+import web5.sdk.dids.DidResolutionResult
+import web5.sdk.dids.PublicKeyPurpose
+import web5.sdk.dids.ResolveDidOptions
+import web5.sdk.dids.validateKeyMaterialInsideKeyManager
 import java.net.URI
 
 /**
@@ -61,10 +67,11 @@ public class CreateDidDhtOptions(
  * @property keyManager A [KeyManager] instance utilized to manage the cryptographic keys associated with the DID.
  * @property didDocument The [DIDDocument] associated with the DID, created by the class.
  */
-public class DidDht(uri: String, keyManager: KeyManager, public val didDocument: DIDDocument? = null) : Did(
-  uri,
-  keyManager
-) {
+public class DidDht private constructor(
+  uri: String,
+  keyManager: KeyManager,
+  public val didDocument: DIDDocument? = null
+) : Did(uri, keyManager) {
 
   /**
    * Resolves the current instance's [uri] to a [DidResolutionResult], which contains the DID Document
@@ -120,10 +127,10 @@ public class DidDht(uri: String, keyManager: KeyManager, public val didDocument:
       val relationshipsMap = mutableMapOf<PublicKeyPurpose, MutableList<VerificationMethod>>().apply {
         val identityVerificationMethodRef = VerificationMethod.builder().id(identityVerificationMethod.id).build()
         listOf(
-            PublicKeyPurpose.AUTHENTICATION,
-            PublicKeyPurpose.ASSERTION_METHOD,
-            PublicKeyPurpose.CAPABILITY_DELEGATION,
-            PublicKeyPurpose.CAPABILITY_INVOCATION
+          PublicKeyPurpose.AUTHENTICATION,
+          PublicKeyPurpose.ASSERTION_METHOD,
+          PublicKeyPurpose.CAPABILITY_DELEGATION,
+          PublicKeyPurpose.CAPABILITY_INVOCATION
         ).forEach { purpose ->
           getOrPut(purpose) { mutableListOf() }.add(identityVerificationMethodRef)
         }
@@ -188,6 +195,22 @@ public class DidDht(uri: String, keyManager: KeyManager, public val didDocument:
      */
     override fun resolve(did: String, options: ResolveDidOptions?): DidResolutionResult {
       TODO("Not yet implemented")
+    }
+
+    override fun load(did: String, keyManager: KeyManager): DidDht {
+      validateKeyMaterialInsideKeyManager(did, keyManager)
+      validateIdentityKey(did, keyManager)
+      return DidDht(did, keyManager, null)
+    }
+
+    private fun validateIdentityKey(did: String, keyManager: KeyManager) {
+      val parsedDid = DID.fromString(did)
+      val decodedId = ZBase32.decode(parsedDid.methodSpecificId)
+      require(decodedId.size == 32) { "expected size of decoded identifier to be 32" }
+
+      val publicKeyJwk = Ed25519.bytesToPublicKey(decodedId)
+      val identityKeyAlias = keyManager.getDeterministicAlias(publicKeyJwk)
+      keyManager.getPublicKey(identityKeyAlias)
     }
 
     /**

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -33,6 +33,7 @@ import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.CreationMetadata
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
+import web5.sdk.dids.DidResolutionMetadata
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.ResolveDidOptions
@@ -57,6 +58,7 @@ import web5.sdk.dids.methods.ion.models.SidetreeDeactivateOperation
 import web5.sdk.dids.methods.ion.models.SidetreeRecoverOperation
 import web5.sdk.dids.methods.ion.models.SidetreeUpdateOperation
 import web5.sdk.dids.methods.ion.models.UpdateOperationSignedData
+import web5.sdk.dids.validateKeyMaterialInsideKeyManager
 import java.net.URI
 import java.security.MessageDigest
 import java.util.UUID
@@ -160,10 +162,10 @@ public class DeactivateDidIonOptions(public val recoveryKeyAlias: String)
  * ### Usage Example:
  * ```kotlin
  * val keyManager = InMemoryKeyManager()
- * val did = DidIon("did:ion:example", keyManager)
+ * val did = DidIon.load("did:ion:example", keyManager)
  * ```
  */
-public class DidIon(
+public class DidIon internal constructor(
   uri: String,
   keyManager: KeyManager,
   public val creationMetadata: IonCreationMetadata? = null,
@@ -287,6 +289,12 @@ public sealed class DidIonApi(
       )
     }
     throw InvalidStatusException(response.status.value, "received error response: '$opBody'")
+  }
+
+  override fun load(did: String, keyManager: KeyManager): DidIon {
+    validateKeyMaterialInsideKeyManager(did, keyManager)
+    // TODO: validate other keys.
+    return DidIon(did, keyManager, null, this)
   }
 
   private fun canonicalized(data: Any): ByteArray {

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -3,7 +3,6 @@ package web5.sdk.dids.methods.key
 import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
-import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
@@ -17,7 +16,7 @@ import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.ResolveDidOptions
-import web5.sdk.dids.findAssertionMethodById
+import web5.sdk.dids.validateKeyMaterialInsideKeyManager
 import java.net.URI
 
 /**
@@ -57,7 +56,7 @@ public class CreateDidKeyOptions(
  * ### Usage Example:
  * ```kotlin
  * val keyManager = InMemoryKeyManager()
- * val did = DidKey("did:key:example", keyManager)
+ * val did = DidKey.load("did:key:example", keyManager)
  * ```
  */
 public class DidKey private constructor(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
@@ -117,20 +116,9 @@ public class DidKey private constructor(uri: String, keyManager: KeyManager) : D
      * Instantiates a [DidKey] instance from a "did:key" DID URI, and validates that the associated key material exists
      * in the provided [keyManager].
      */
-    public fun load(did: String, keyManager: KeyManager): DidKey {
-      require(DID.fromString(did).methodName == methodName) {
-        "did must start with the prefix \"id:key\", but got $did"
-      }
-      val didKey = DidKey(did, keyManager)
-      validateKeyMaterialInsideKeyManager(didKey, keyManager)
-      return didKey
-    }
-
-    private fun validateKeyMaterialInsideKeyManager(didKey: DidKey, keyManager: KeyManager) {
-      val verificationMethod = didKey.findAssertionMethodById(null)
-      val publicKeyJwk = JWK.parse(verificationMethod.publicKeyJwk)
-      val keyAlias = keyManager.getDeterministicAlias(publicKeyJwk)
-      keyManager.getPublicKey(keyAlias)
+    override fun load(did: String, keyManager: KeyManager): DidKey {
+      validateKeyMaterialInsideKeyManager(did, keyManager)
+      return DidKey(did, keyManager)
     }
 
     /**
@@ -188,3 +176,4 @@ public class DidKey private constructor(uri: String, keyManager: KeyManager) : D
     }
   }
 }
+

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.JWK
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
@@ -28,6 +27,7 @@ import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service
 import web5.sdk.dids.methods.ion.models.SidetreeCreateOperation
 import web5.sdk.dids.methods.ion.models.SidetreeUpdateOperation
+import web5.sdk.dids.methods.util.readKey
 import java.io.File
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -196,12 +196,6 @@ class DidIonTest {
     val did = manager.create(keyManager, opts)
     assertContains(did.uri, "did:ion:")
     assertContains(did.creationMetadata!!.longFormDid, did.creationMetadata!!.shortFormDid)
-  }
-
-  private fun readKey(pathname: String): JWK {
-    return JWK.parse(
-      File(pathname).readText()
-    )
   }
 
   @Test

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
@@ -11,6 +11,7 @@ import com.nimbusds.jose.jwk.JWK
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.DidResolvers
 import kotlin.test.assertEquals
@@ -35,6 +36,33 @@ class DidKeyTest {
       val keyAlias = did.keyManager.getDeterministicAlias(jwk)
       val publicKey = did.keyManager.getPublicKey(keyAlias)
     }
+  }
+
+  @Test
+  fun `load fails when key manager does not contain private key`() {
+    val manager = InMemoryKeyManager()
+    val exception = assertThrows<IllegalArgumentException> {
+      DidKey.load("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp", manager)
+    }
+    assertEquals("key with alias 9ZP03Nu8GrXPAUkbKNxHOKBzxPX83SShgFkRNK-f2lw not found", exception.message)
+  }
+
+  @Test
+  fun `load returns instance when key manager contains private key`() {
+    val manager = InMemoryKeyManager()
+    val did = DidKey.create(manager)
+    val didKey = DidKey.load(did.uri, manager)
+    assertEquals(did.uri, didKey.uri)
+  }
+
+  @Test
+  fun `throws exception when loading a different type of did`() {
+    val manager = InMemoryKeyManager()
+    val did = DidKey.create(manager)
+    val exception = assertThrows<IllegalArgumentException> {
+      DidKey.load(did.uri.replace("key", "ion"), manager)
+    }
+    assertTrue(exception.message!!.startsWith("did must start with the prefix \"id:key\""))
   }
 
   @Nested
@@ -99,7 +127,7 @@ class DidKeyTest {
         val km2 = InMemoryKeyManager()
         km2.import(jsonKeySet)
 
-        DidKey(uri = didUri, keyManager = km2)
+        DidKey.load(did = didUri, keyManager = km2)
       }
     }
   }

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
@@ -62,7 +62,7 @@ class DidKeyTest {
     val exception = assertThrows<IllegalArgumentException> {
       DidKey.load(did.uri.replace("key", "ion"), manager)
     }
-    assertTrue(exception.message!!.startsWith("did must start with the prefix \"id:key\""))
+    assertTrue(exception.message!!.startsWith("did must start with the prefix \"did:key\""))
   }
 
   @Nested

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/util/TestUtils.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/util/TestUtils.kt
@@ -1,0 +1,11 @@
+package web5.sdk.dids.methods.util
+
+import com.nimbusds.jose.jwk.JWK
+import java.io.File
+
+
+fun readKey(pathname: String): JWK {
+  return JWK.parse(
+    File(pathname).readText()
+  )
+}

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/web/DidWebTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/web/DidWebTest.kt
@@ -1,4 +1,4 @@
-package web5.sdk.dids
+package web5.sdk.dids.methods.web
 
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -8,6 +8,11 @@ import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.DidWeb
+import web5.sdk.dids.DidWebApi
+import web5.sdk.dids.methods.util.readKey
+import java.io.File
 import kotlin.test.assertEquals
 
 class DidWebTest {
@@ -54,6 +59,27 @@ class DidWebTest {
     }
   }
 
+  @Test
+  fun `load returns instance when key manager contains private key`() {
+    val manager = InMemoryKeyManager()
+    val privateJwk = readKey("src/test/resources/jwkEs256k1Private.json")
+    manager.import(privateJwk)
+    DidWebApi {
+      engine = mockEngine()
+    }.load("did:web:example-with-verification-method.com", manager)
+  }
+
+  @Test
+  fun `load throws exception when key manager does not contain private key`() {
+    val manager = InMemoryKeyManager()
+    val exception = assertThrows<IllegalArgumentException> {
+      DidWebApi {
+        engine = mockEngine()
+      }.load("did:web:example-with-verification-method.com", manager)
+    }
+    assertEquals("key with alias CfveyLOfYrOhSgD66MA6PO9J5sAnj_J-Z0URcD6VGVU not found", exception.message)
+  }
+
   private fun mockEngine() = MockEngine { request ->
     when (request.url.toString()) {
       "https://example.com/.well-known/did.json" -> {
@@ -75,6 +101,16 @@ class DidWebTest {
       "https://example.com:3000/user/alice/did.json" -> {
         respond(
           content = ByteReadChannel("""{"id": "did:web:example.com%3A3000:user:alice"}"""),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "https://example-with-verification-method.com/.well-known/did.json" -> {
+        respond(
+          content = ByteReadChannel(
+            File("src/test/resources/did_document_jwkEx256k1Public_assertion.json").readText()
+          ),
           status = HttpStatusCode.OK,
           headers = headersOf(HttpHeaders.ContentType, "application/json")
         )

--- a/dids/src/test/resources/did_document_jwkEx256k1Public_assertion.json
+++ b/dids/src/test/resources/did_document_jwkEx256k1Public_assertion.json
@@ -1,0 +1,29 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:example-with-verification-method.com",
+  "verificationMethod": [
+    {
+      "controller": "did:web:example-with-verification-method.com",
+      "id": "did:example:123#key-0",
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "nIqlRCx0eyBSXcQnqDpReSv4zuWhwCRWssoc9L_nj6A",
+        "y": "iG29VK6l2U5sKBZUSJePvyFusXgSlK2dDFlWaCM8F7k"
+      },
+      "type": "JsonWebKey2020"
+    }
+  ],
+  "authentication": [
+    "did:web:example-with-verification-method.com#key-0"
+  ],
+  "assertionMethod": [
+    "did:web:example-with-verification-method.com#key-0"
+  ],
+  "keyAgreement": [
+    "did:web:example-with-verification-method.com#key-0"
+  ]
+}


### PR DESCRIPTION
# Overview
This PR fixes #112 by exposing a `load` method in the `DidMethod` interface. This method is meant to be used when a caller wants to create a `Did` instance with a `KeyManager` that already contains the private keys for the given Did. It performs validation that all the required

# Description
* Constructors were made private or internal.
* Implementations of `load` for each `DidMethod` were added. 
* The `DidDht` is untested, given that the `resolve` function isn't yet done.
* There is not reliable way yet to check whether the `DidIon` update and recovery keys are present in the `KeyManager`, so that was left as a TODO.

# How Has This Been Tested?
Unit tests for `DidWeb` and `DidKey`.
