### PR TITLE
Implementing satisfiesPresentationDefinition

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
@@ -62,6 +62,7 @@ public object PresentationExchange {
       )
     }
   }
+
   private fun mapInputDescriptorsToVCs(
     vcJwtList: List<String>,
     presentationDefinition: PresentationDefinitionV2

--- a/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
@@ -30,12 +30,17 @@ public object PresentationExchange {
   }
 
   /**
-   * Validates if a Verifiable Credential JWT satisfies a Presentation Definition.
+   * Validates a list of Verifiable Credentials (VCs) against a specified Presentation Definition.
    *
-   * @param vcJwts The Verifiable Credentials as a JWT string.
-   * @param presentationDefinition The Presentation Definition to validate against.
-   * @throws UnsupportedOperationException If the Presentation Definition's Submission Requirements exists
-   * @throws PresentationExchangeError If the Presentation Definition is not fulfilled
+   * This function ensures that the provided VCs meet the criteria defined in the Presentation Definition.
+   * It first checks for the presence of Submission Requirements in the definition and throws an exception if they exist,
+   * as this feature is not implemented. Then, it maps the input descriptors in the presentation definition to the
+   * corresponding VCs. If the number of mapped descriptors does not match the required count, an error is thrown.
+   *
+   * @param vcJwts List of VCs in JWT format to validate.
+   * @param presentationDefinition The Presentation Definition V2 object against which VCs are validated.
+   * @throws UnsupportedOperationException If Submission Requirements are present in the definition.
+   * @throws PresentationExchangeError If the number of input descriptors matched is less than required.
    */
   public fun satisfiesPresentationDefinition(
     vcJwts: List<String>,

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -12,6 +12,9 @@ import web5.sdk.dids.methods.key.DidKey
 import java.io.File
 import kotlin.test.Test
 
+data class DateOfBirth(val dateOfBirth: String)
+data class Address(val address: String)
+data class DateOfBirthSSN(val dateOfBirth: String, val ssn: String)
 class PresentationExchangeTest {
   private val keyManager = InMemoryKeyManager()
   private val issuerDid = DidKey.create(keyManager)
@@ -38,7 +41,7 @@ class PresentationExchangeTest {
         PresentationDefinitionV2::class.java
       )
 
-      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(sanctionsVcJwt, pd) }
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(sanctionsVcJwt), pd) }
     }
 
     @Test
@@ -55,7 +58,7 @@ class PresentationExchangeTest {
       )
       val vcJwt = vc.sign(issuerDid)
 
-      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(vcJwt, pd) }
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
 
     @Test
@@ -72,11 +75,11 @@ class PresentationExchangeTest {
       )
       val vcJwt = vc.sign(issuerDid)
 
-      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(vcJwt, pd) }
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
 
     @Test
-    fun `does not throw when VC satisfies PD with field constraint`() {
+    fun `does not throw when VC satisfies PD with no filter field constraint`() {
       val pd = jsonMapper.readValue(
         readPd("src/test/resources/pd_path_no_filter.json"),
         PresentationDefinitionV2::class.java
@@ -89,11 +92,119 @@ class PresentationExchangeTest {
       )
       val vcJwt = vc.sign(issuerDid)
 
-      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(vcJwt, pd) }
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
 
     @Test
-    fun `throws when VC does not satisfy requirements`() {
+    fun `does not throw when VC satisfies PD with no filter dob filed constraint`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_path_no_filter_dob.json"),
+        PresentationDefinitionV2::class.java
+      )
+
+      val vc = VerifiableCredential.create(
+        type = "DateOfBirthVc",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirth(dateOfBirth = "1/1/1111")
+      )
+
+      val vcJwt = vc.sign(issuerDid)
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
+    }
+
+    @Test
+    fun `does not throw when VC satisfies PD with no filter dob filed constraint and extra VC`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_path_no_filter_dob.json"),
+        PresentationDefinitionV2::class.java
+      )
+
+      val vc1 = VerifiableCredential.create(
+        type = "DateOfBirth",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirth(dateOfBirth = "Data1")
+      )
+      val vcJwt1 = vc1.sign(issuerDid)
+
+      val vc2 = VerifiableCredential.create(
+        type = "Address",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = Address("abc street 123")
+      )
+      val vcJwt2 = vc2.sign(issuerDid)
+
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt2, vcJwt1), pd) }
+    }
+
+    @Test
+    fun `does not throw when one VC satisfies both input descriptors PD`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_filter_array_multiple_input_descriptors.json"),
+        PresentationDefinitionV2::class.java
+      )
+
+      val vc1 = VerifiableCredential.create(
+        type = "DateOfBirthSSN",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirthSSN(dateOfBirth = "1999-01-01", ssn = "456-123-123")
+      )
+      val vcJwt1 = vc1.sign(issuerDid)
+
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt1), pd) }
+    }
+
+    @Test
+    fun `does not throw when one VC satisfies both input descriptors PD mixed filter`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_mixed_multiple_input_descriptors.json"),
+        PresentationDefinitionV2::class.java
+      )
+
+      val vc1 = VerifiableCredential.create(
+        type = "DateOfBirthSSN",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirthSSN(dateOfBirth = "1999-01-01", ssn = "456-123-123")
+      )
+      val vcJwt1 = vc1.sign(issuerDid)
+
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt1), pd) }
+    }
+
+    @Test
+    fun `does not throw when a valid presentation submission has two vc`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_path_no_filter_multiple_input_descriptors.json"),
+        PresentationDefinitionV2::class.java
+      )
+
+      val vc1 = VerifiableCredential.create(
+        type = "DateOfBirthVc",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirth(dateOfBirth = "1/1/1111")
+      )
+
+      val vcJwt1 = vc1.sign(issuerDid)
+
+      val vc2 = VerifiableCredential.create(
+        type = "Address",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = Address(address = "123 abc street")
+      )
+
+      val vcJwt2 = vc2.sign(issuerDid)
+
+      assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt2, vcJwt1), pd) }
+    }
+
+    @Test
+    fun `throws when VC does not satisfy sanctions requirements`() {
       val pd = jsonMapper.readValue(
         readPd("src/test/resources/pd_sanctions.json"),
         PresentationDefinitionV2::class.java
@@ -107,8 +218,47 @@ class PresentationExchangeTest {
       val vcJwt = vc.sign(issuerDid)
 
       assertFailure {
-        PresentationExchange.satisfiesPresentationDefinition(vcJwt, pd)
-      }.messageContains("Validating [\"VerifiableCredential\",\"StreetCred\"]")
+        PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
+      }.messageContains("Missing input descriptors: The presentation definition requires")
+    }
+
+
+    @Test
+    fun `throws when VC does not satisfy no filter dob requirements`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_path_no_filter_dob.json"),
+        PresentationDefinitionV2::class.java
+      )
+      val vc = VerifiableCredential.create(
+        type = "StreetCred",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = StreetCredibility(localRespect = "high", legit = true)
+      )
+      val vcJwt = vc.sign(issuerDid)
+
+      assertFailure {
+        PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
+      }.messageContains("Missing input descriptors: The presentation definition requires")
+    }
+
+    @Test
+    fun `throws when VC does not satisfy filter streetCred requirements`() {
+      val pd = jsonMapper.readValue(
+        readPd("src/test/resources/pd_filter_array.json"),
+        PresentationDefinitionV2::class.java
+      )
+      val vc = VerifiableCredential.create(
+        type = "DateOfBirth",
+        issuer = issuerDid.uri,
+        subject = holderDid.uri,
+        data = DateOfBirth(dateOfBirth = "01-02-03")
+      )
+      val vcJwt = vc.sign(issuerDid)
+
+      assertFailure {
+        PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
+      }.messageContains("Missing input descriptors: The presentation definition requires")
     }
   }
 }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -113,7 +113,7 @@ class PresentationExchangeTest {
     }
 
     @Test
-    fun `does not throw when VC satisfies PD with no filter dob filed constraint`() {
+    fun `does not throw when VC satisfies PD with no filter dob field constraint`() {
       val pd = jsonMapper.readValue(
         readPd("src/test/resources/pd_path_no_filter_dob.json"),
         PresentationDefinitionV2::class.java

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -131,7 +131,7 @@ class PresentationExchangeTest {
     }
 
     @Test
-    fun `does not throw when VC satisfies PD with no filter dob filed constraint and extra VC`() {
+    fun `does not throw when VC satisfies PD with no filter dob field constraint and extra VC`() {
       val pd = jsonMapper.readValue(
         readPd("src/test/resources/pd_path_no_filter_dob.json"),
         PresentationDefinitionV2::class.java

--- a/credentials/src/test/resources/pd_filter_array.json
+++ b/credentials/src/test/resources/pd_filter_array.json
@@ -12,10 +12,7 @@
             ],
             "filter": {
               "type": "string",
-              "contains": {
-                "type": "string",
-                "const": "StreetCred"
-              }
+              "pattern": ".*StreetCred.*"
             }
           }
         ]

--- a/credentials/src/test/resources/pd_filter_array_multiple_input_descriptors.json
+++ b/credentials/src/test/resources/pd_filter_array_multiple_input_descriptors.json
@@ -1,0 +1,38 @@
+{
+  "id": "ec11a434-fe24-479b-aae0-511428b37e4f",
+  "input_descriptors": [
+    {
+      "id": "input-descriptor-id-1",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.dateOfBirth",
+              "$.vc.credentialSubject.dateOfBirth"
+            ],
+            "filter": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "input-descriptor-id-2",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.ssn",
+              "$.vc.credentialSubject.ssn"
+            ],
+            "filter": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/credentials/src/test/resources/pd_filter_array_single_path.json
+++ b/credentials/src/test/resources/pd_filter_array_single_path.json
@@ -1,0 +1,24 @@
+{
+  "id": "ec11a434-fe24-479b-aae0-511428b37e4f",
+  "input_descriptors": [
+    {
+      "id": "7b928839-f0b1-4237-893d-b27124b57952",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.vc.type"
+            ],
+            "filter": {
+              "type": "array",
+              "contains": {
+                "type": "string",
+                "const": "StreetCred"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/credentials/src/test/resources/pd_mixed_multiple_input_descriptors.json
+++ b/credentials/src/test/resources/pd_mixed_multiple_input_descriptors.json
@@ -1,0 +1,35 @@
+{
+  "id": "ec11a434-fe24-479b-aae0-511428b37e4f",
+  "input_descriptors": [
+    {
+      "id": "input-descriptor-id-1",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.dateOfBirth",
+              "$.vc.credentialSubject.dateOfBirth"
+            ],
+            "filter": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "input-descriptor-id-2",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.ssn",
+              "$.vc.credentialSubject.ssn"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/credentials/src/test/resources/pd_path_no_filter_dob.json
+++ b/credentials/src/test/resources/pd_path_no_filter_dob.json
@@ -1,0 +1,18 @@
+{
+  "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+  "input_descriptors": [
+    {
+      "id": "wa_driver_license",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.dateOfBirth",
+              "$.vc.credentialSubject.dateOfBirth"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/credentials/src/test/resources/pd_path_no_filter_multiple_input_descriptors.json
+++ b/credentials/src/test/resources/pd_path_no_filter_multiple_input_descriptors.json
@@ -1,0 +1,31 @@
+{
+  "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+  "input_descriptors": [
+    {
+      "id": "dob-input-descriptor-id",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.dateOfBirth",
+              "$.vc.credentialSubject.dateOfBirth"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "address-input-descriptor-id",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.address",
+              "$.vc.credentialSubject.address"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Implementing satisfiesPresentationDefinition function for PEX

Validates a list of Verifiable Credentials (VCs) against a specified Presentation Definition.

This function ensures that the provided VCs meet the criteria defined in the Presentation Definition.

It first checks for the presence of Submission Requirements in the definition and throws an exception if they exist (not supported

It does this by mapping the input descriptors in the presentation definition to the corresponding VCs. If the number of mapped descriptors does not match the required count, an error is thrown.

More detailed error messages are planned for the future with a Results object that will give warnings, and better details for errors