### PR TITLE
Replace `verificationMethods` type in `did:dht` to use `VerificationMethodSpec`

### DIFF
--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -16,8 +16,8 @@ import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
-import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
 import web5.sdk.dids.methods.key.DidKey
+import web5.sdk.dids.verificationmethods.JsonWebKey2020VerificationMethod
 import java.security.SignatureException
 import java.text.ParseException
 import java.util.UUID

--- a/dids/src/main/kotlin/web5/sdk/dids/Models.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/Models.kt
@@ -1,6 +1,17 @@
 package web5.sdk.dids
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.nimbusds.jose.jwk.JWK
 
 /**
  * Enum representing the purpose of a public key.
@@ -11,4 +22,47 @@ public enum class PublicKeyPurpose(@get:JsonValue public val code: String) {
   ASSERTION_METHOD("assertionMethod"),
   CAPABILITY_DELEGATION("capabilityDelegation"),
   CAPABILITY_INVOCATION("capabilityInvocation"),
+}
+
+/**
+ * Represents a public key in the ION document as defined in item 3 of https://identity.foundation/sidetree/spec/#add-public-keys
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public data class PublicKey(
+  public val id: String,
+  public val type: String,
+  public val controller: String? = null,
+
+  @JsonSerialize(using = JacksonJwk.Serializer::class)
+  @JsonDeserialize(using = JacksonJwk.Deserializer::class)
+  public val publicKeyJwk: JWK,
+  public val purposes: Iterable<PublicKeyPurpose> = emptyList()
+)
+
+/**
+ * JacksonJWK is a utility class that facilitates serialization for [JWK] types, so that it's easy to integrate with any
+ * class that is meant to be serialized to/from JSON.
+ */
+public class JacksonJwk {
+  /**
+   * [Serializer] implements [JsonSerializer] for use with the [JsonSerialize] annotation from Jackson.
+   */
+  public object Serializer : JsonSerializer<JWK>() {
+    override fun serialize(value: JWK, gen: JsonGenerator, serializers: SerializerProvider) {
+      with(gen) {
+        writeObject(value.toJSONObject())
+      }
+    }
+  }
+
+  /**
+   * [Deserializer] implements [JsonDeserializer] for use with the [JsonDeserialize] annotation from Jackson.
+   */
+  public object Deserializer : JsonDeserializer<JWK>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): JWK {
+      val typeRef = object : TypeReference<HashMap<String, Any>>() {}
+      val node = p.readValueAs(typeRef) as HashMap<String, Any>
+      return JWK.parse(node)
+    }
+  }
 }

--- a/dids/src/main/kotlin/web5/sdk/dids/verificationmethods/VerificationMethod.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/verificationmethods/VerificationMethod.kt
@@ -1,0 +1,118 @@
+package web5.sdk.dids.verificationmethods
+
+import com.nimbusds.jose.Algorithm
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWK
+import web5.sdk.crypto.KeyGenOptions
+import web5.sdk.crypto.KeyManager
+import web5.sdk.dids.PublicKey
+import web5.sdk.dids.PublicKeyPurpose
+import java.util.UUID
+
+/** Common interface for options available when adding a VerificationMethod. */
+public interface VerificationMethodSpec
+
+/** Common interface for classes that can generate a [PublicKey] from a [VerificationMethodSpec]. */
+public interface VerificationMethodGenerator {
+  /**
+   * Generates a [PublicKey] from a [VerificationMethodSpec]. The first element of the pair is an optional id that can
+   * be used to identify the private key associated with the generated public key.
+   */
+  public fun generate(): Pair<String?, PublicKey>
+}
+
+/**
+ * A [VerificationMethodSpec] where a [KeyManager] will be used to generate the underlying verification method keys.
+ * The parameters [algorithm], [curve], and [options] will be forwarded to the keyManager.
+ *
+ * [relationships] will be used to determine the verification relationships in the DID Document being created.
+ * */
+public class VerificationMethodCreationParams(
+  public val algorithm: Algorithm,
+  public val curve: Curve? = null,
+  public val options: KeyGenOptions? = null,
+  public val relationships: Iterable<PublicKeyPurpose>
+) : VerificationMethodSpec {
+  internal fun toGenerator(keyManager: KeyManager): VerificationMethodKeyManagerGenerator {
+    return VerificationMethodKeyManagerGenerator(keyManager, this)
+  }
+}
+
+/**
+ * A [VerificationMethodSpec] according to https://w3c-ccg.github.io/lds-jws2020/.
+ *
+ * The [id] property cannot be over 50 chars and must only use characters from the Base64URL character set.
+ */
+public class JsonWebKey2020VerificationMethod(
+  public val id: String,
+  public val controller: String? = null,
+  public val publicKeyJwk: JWK,
+  public val relationships: Iterable<PublicKeyPurpose> = emptySet()
+) : VerificationMethodSpec, VerificationMethodGenerator {
+  override fun generate(): Pair<String?, PublicKey> {
+    return Pair(null, PublicKey(id, "JsonWebKey2020", controller, publicKeyJwk, relationships))
+  }
+}
+
+/**
+ * A [VerificationMethodSpec] according to https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/.
+ *
+ * The [id] property cannot be over 50 chars and must only use characters from the Base64URL character set.
+ */
+public class EcdsaSecp256k1VerificationKey2019VerificationMethod(
+  public val id: String,
+  public val controller: String? = null,
+  public val publicKeyJwk: JWK,
+  public val relationships: Iterable<PublicKeyPurpose> = emptySet()
+) : VerificationMethodSpec, VerificationMethodGenerator {
+  override fun generate(): Pair<String, PublicKey> {
+    return Pair(id, PublicKey(id, "EcdsaSecp256k1VerificationKey2019", controller, publicKeyJwk, relationships))
+  }
+}
+
+internal class VerificationMethodKeyManagerGenerator(
+  val keyManager: KeyManager,
+  val params: VerificationMethodCreationParams,
+) : VerificationMethodGenerator {
+
+  override fun generate(): Pair<String, PublicKey> {
+    val alias = keyManager.generatePrivateKey(
+      algorithm = params.algorithm,
+      curve = params.curve,
+      options = params.options
+    )
+    val publicKeyJwk = keyManager.getPublicKey(alias)
+    return Pair(
+      alias,
+      PublicKey(
+        id = UUID.randomUUID().toString(),
+        type = "JsonWebKey2020",
+        publicKeyJwk = publicKeyJwk,
+        purposes = params.relationships,
+      )
+    )
+  }
+}
+
+/**
+ * Converts a list of [VerificationMethodSpec] to a list of [VerificationMethodGenerator]s with the given [keyManager].
+ */
+public fun Iterable<VerificationMethodSpec>.toGenerators(keyManager: KeyManager): List<VerificationMethodGenerator> {
+  return buildList {
+    for (verificationMethodSpec in this@toGenerators) {
+      when (verificationMethodSpec) {
+        is VerificationMethodCreationParams -> add(verificationMethodSpec.toGenerator(keyManager))
+
+        is VerificationMethodGenerator -> add(verificationMethodSpec)
+      }
+    }
+  }
+}
+
+/**
+ * Converts a list of [VerificationMethodSpec] to a list of [PublicKey]s with the given [keyManager].
+ */
+public fun Iterable<VerificationMethodSpec>.toPublicKeys(keyManager: KeyManager)
+  : List<Pair<String?, PublicKey>> = toGenerators(
+  keyManager
+).map { it.generate() }

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -22,12 +22,16 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.PublicKey
 import web5.sdk.dids.PublicKeyPurpose
-import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service
 import web5.sdk.dids.methods.ion.models.SidetreeCreateOperation
 import web5.sdk.dids.methods.ion.models.SidetreeUpdateOperation
 import web5.sdk.dids.methods.util.readKey
+import web5.sdk.dids.verificationmethods.EcdsaSecp256k1VerificationKey2019VerificationMethod
+import web5.sdk.dids.verificationmethods.JsonWebKey2020VerificationMethod
+import web5.sdk.dids.verificationmethods.VerificationMethodCreationParams
+import web5.sdk.dids.verificationmethods.VerificationMethodSpec
 import java.io.File
 import kotlin.test.Ignore
 import kotlin.test.Test


### PR DESCRIPTION
# Overview
This PR makes the `CreateDid{Dht,Ion}Options` consistent, and allows users to create `dht` dids without having to worry about the key creation for the verification methods.

# Description
See the updated `DidDhtTest.kt` file to understand how we allow consumers to create `VerificationMethods` with or without a `KeyManager`. 

# How Has This Been Tested?
Simple refactor. I just moved stuff around and _slightly_ updated tests.


## References
See the original `did:ion` PR that allowed this in #96 