### PR TITLE
Allow public constructors for Did subclasses

### DIFF
--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -159,7 +159,7 @@ public class DeactivateDidIonOptions(public val recoveryKeyAlias: String)
  * @property creationMetadata Metadata related to the creation of a DID. Useful for debugging purposes.
  * @property didIonApi A [DidIonApi] instance utilized to delegate all the calls to an ION node.
  */
-public class DidIon internal constructor(
+public class DidIon(
   uri: String,
   keyManager: KeyManager,
   public val creationMetadata: IonCreationMetadata? = null,

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -53,7 +53,7 @@ public class CreateDidJwkOptions(
  *
  * @constructor Initializes a new instance of [DidJwk] with the provided [uri] and [keyManager].
  */
-public class DidJwk private constructor(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
+public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
   /**
    * Resolves the current instance's [uri] to a [DidResolutionResult], which contains the DID Document
    * and possible related metadata.

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -53,7 +53,7 @@ public class CreateDidKeyOptions(
  *
  * @constructor Initializes a new instance of [DidKey] with the provided [uri] and [keyManager].
  */
-public class DidKey private constructor(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
+public class DidKey(uri: String, keyManager: KeyManager) : Did(uri, keyManager) {
   /**
    * Resolves the current instance's [uri] to a [DidResolutionResult], which contains the DID Document
    * and possible related metadata.

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
@@ -41,7 +41,7 @@ import kotlin.text.Charsets.UTF_8
  * val did = StatefulWebDid("did:web:tbd.website", keyManager)
  * ```
  */
-public class DidWeb internal constructor(
+public class DidWeb(
   uri: String,
   keyManager: KeyManager,
   private val didWebApi: DidWebApi


### PR DESCRIPTION
While we come to consensus on #112 , we're allowing constructors to be public of subclasses of `Did` to be public. 