### PR TITLE
Replace externally defined enums `Curve` and `Algorithm`

### DIFF
--- a/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
+++ b/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
@@ -1,10 +1,10 @@
 package web5.sdk.common
 
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.JWSAlgorithm
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 

--- a/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
+++ b/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
@@ -2,9 +2,9 @@ package web5.sdk.common
 
 import com.nimbusds.jose.jwk.Curve
 import org.junit.jupiter.api.Test
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.JWSAlgorithm
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
@@ -40,7 +40,7 @@ class ZBase32Test {
     val manager = InMemoryKeyManager()
 
     for (i in 0..50) {
-      val keyAlias = manager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Algorithm.EdDSA, Curve.Ed25519)
       val pubKeyJwk = manager.getPublicKey(keyAlias)
       val pubKeyBytes = Crypto.publicKeyToBytes(pubKeyJwk)
       val encodedPubKey = ZBase32.encode(pubKeyBytes)

--- a/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
+++ b/common/src/test/kotlin/web5/sdk/common/ZBase32Test.kt
@@ -1,9 +1,9 @@
 package web5.sdk.common
 
-import com.nimbusds.jose.jwk.Curve
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.InMemoryKeyManager
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -20,7 +20,7 @@ import foundation.identity.did.DIDURL
 import foundation.identity.did.VerificationMethod
 import web5.sdk.common.Convert
 import web5.sdk.crypto.Crypto
-import web5.sdk.crypto.toWeb5JWSAlgorithm
+import web5.sdk.crypto.toWeb5Algorithm
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidResolvers
 import web5.sdk.dids.findAssertionMethodById
@@ -264,7 +264,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
       val toVerifyBytes = jwt.signingInput
       val signatureBytes = jwt.signature.decode()
 
-      Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm.toWeb5JWSAlgorithm())
+      Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm.toWeb5Algorithm())
     }
 
     /**

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.module.kotlin.convertValue
 import com.nfeld.jsonpathkt.JsonPath
 import com.nfeld.jsonpathkt.extension.read
 import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.util.Base64URL
@@ -21,6 +20,7 @@ import foundation.identity.did.DIDURL
 import foundation.identity.did.VerificationMethod
 import web5.sdk.common.Convert
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.toWeb5JWSAlgorithm
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidResolvers
 import web5.sdk.dids.findAssertionMethodById
@@ -82,7 +82,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
 
     // TODO: figure out how to make more reliable since algorithm is technically not a required property of a JWK
     val algorithm = publicKeyJwk.algorithm
-    val jwsAlgorithm = JWSAlgorithm.parse(algorithm.toString())
+    val jwsAlgorithm = com.nimbusds.jose.JWSAlgorithm.parse(algorithm.toString())
 
     val kid = when (assertionMethod.id.isAbsolute) {
       true -> assertionMethod.id.toString()
@@ -264,7 +264,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
       val toVerifyBytes = jwt.signingInput
       val signatureBytes = jwt.signature.decode()
 
-      Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm)
+      Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm.toWeb5JWSAlgorithm())
     }
 
     /**

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -1,7 +1,6 @@
 package web5.sdk.credentials
 
 import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSSigner
 import com.nimbusds.jose.crypto.Ed25519Signer
@@ -14,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
 import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
@@ -164,7 +164,7 @@ class VerifiableCredentialTest {
       CreateDidIonOptions(verificationMethodsToAdd = listOf(key))
     )
 
-    val header = JWSHeader.Builder(JWSAlgorithm.ES256K)
+    val header = JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.ES256K)
       .keyID(issuerDid.uri)
       .build()
     //A detached payload JWT
@@ -196,7 +196,7 @@ class VerifiableCredentialTest {
       .build()
 
     val signedJWT = SignedJWT(
-      JWSHeader.Builder(JWSAlgorithm.EdDSA).keyID(jwk.keyID).build(),
+      JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.EdDSA).keyID(jwk.keyID).build(),
       claimsSet
     )
 
@@ -220,7 +220,7 @@ class VerifiableCredentialTest {
       .build()
 
     val signedJWT = SignedJWT(
-      JWSHeader.Builder(JWSAlgorithm.EdDSA).keyID(jwk.keyID).build(),
+      JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.EdDSA).keyID(jwk.keyID).build(),
       claimsSet
     )
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -11,9 +11,9 @@ import com.nimbusds.jwt.SignedJWT
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
 import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
@@ -152,7 +152,7 @@ class VerifiableCredentialTest {
     val keyManager = InMemoryKeyManager()
 
     //Create an ION DID without an assertionMethod
-    val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val verificationJwk = keyManager.getPublicKey(alias)
     val key = JsonWebKey2020VerificationMethod(
       id = UUID.randomUUID().toString(),

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Algorithm.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Algorithm.kt
@@ -3,14 +3,14 @@ package web5.sdk.crypto
 /**
  * The supported JSON Web Signature algorithms.
  */
-public enum class JWSAlgorithm {
+public enum class Algorithm {
   /** ECDSA using secp256k1 curve and SHA-256. */
   ES256K,
 
   /** Edwards-curve Digital Signature Algorithm. */
   EdDSA;
 
-  internal fun toJwsAlgorithm(): com.nimbusds.jose.JWSAlgorithm {
+  internal fun toNimbusdsJWSAlgorithm(): com.nimbusds.jose.JWSAlgorithm {
     return when (this) {
       ES256K -> com.nimbusds.jose.JWSAlgorithm.ES256K
       EdDSA -> com.nimbusds.jose.JWSAlgorithm.EdDSA

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Algorithm.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Algorithm.kt
@@ -17,3 +17,10 @@ public enum class Algorithm {
     }
   }
 }
+
+/**
+ * Converts an [Algorithm] from the nimbusds library to a [Algorithm].
+ */
+public fun com.nimbusds.jose.Algorithm?.toWeb5Algorithm(): Algorithm? {
+  return this?.name?.let { Algorithm.valueOf(it) }
+}

--- a/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
@@ -13,7 +13,6 @@ import com.amazonaws.services.kms.model.MessageType
 import com.amazonaws.services.kms.model.SignRequest
 import com.amazonaws.services.kms.model.SigningAlgorithmSpec
 import com.nimbusds.jose.crypto.impl.ECDSA
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
@@ -129,7 +128,7 @@ public class AwsKeyManager @JvmOverloads constructor(
 
     val algorithmDetails = getAlgorithmDetails(publicKeyResponse.keySpec.enum())
     val jwkBuilder = when (publicKey) {
-      is ECPublicKey -> ECKey.Builder(algorithmDetails.curve, publicKey)
+      is ECPublicKey -> ECKey.Builder(algorithmDetails.curve.toNimbusdsCurve(), publicKey)
       else -> throw IllegalArgumentException("Unknown key type $publicKey")
     }
     return jwkBuilder

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import web5.sdk.crypto.Crypto.generatePrivateKey
 import web5.sdk.crypto.Crypto.publicKeyToBytes

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
@@ -1,13 +1,12 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import web5.sdk.crypto.Crypto.generatePrivateKey
 import web5.sdk.crypto.Crypto.publicKeyToBytes
 import web5.sdk.crypto.Crypto.sign
 
-public typealias CryptoAlgorithm = Pair<JWSAlgorithm?, Curve?>
+public typealias CryptoAlgorithm = Pair<Algorithm?, Curve?>
 
 /**
  * Cryptography utility object providing key generation, signature creation, and other crypto-related functionalities.
@@ -74,7 +73,7 @@ public object Crypto {
    * @return The generated private key as a JWK object.
    * @throws IllegalArgumentException if the provided algorithm or curve is not supported.
    */
-  public fun generatePrivateKey(algorithm: JWSAlgorithm, curve: Curve? = null, options: KeyGenOptions? = null): JWK {
+  public fun generatePrivateKey(algorithm: Algorithm, curve: Curve? = null, options: KeyGenOptions? = null): JWK {
     val keyGenerator = getKeyGenerator(algorithm, curve)
     return keyGenerator.generatePrivateKey(options)
   }
@@ -88,7 +87,7 @@ public object Crypto {
   public fun computePublicKey(privateKey: JWK): JWK {
     val rawCurve = privateKey.toJSONObject()["crv"]
     val curve = rawCurve?.let { Curve.parse(it.toString()) }
-    val generator = getKeyGenerator(privateKey.algorithm?.name?.let { JWSAlgorithm.valueOf(it) }, curve)
+    val generator = getKeyGenerator(privateKey.algorithm?.name?.let { Algorithm.valueOf(it) }, curve)
 
     return generator.computePublicKey(privateKey)
   }
@@ -108,7 +107,7 @@ public object Crypto {
     val rawCurve = privateKey.toJSONObject()["crv"]
     val curve = rawCurve?.let { Curve.parse(it.toString()) }
 
-    val signer = getSigner(privateKey.algorithm.toWeb5JWSAlgorithm(), curve)
+    val signer = getSigner(privateKey.algorithm.toWeb5Algorithm(), curve)
 
     return signer.sign(privateKey, payload, options)
   }
@@ -135,8 +134,8 @@ public object Crypto {
    *                                  provides an algorithm.
    *
    */
-  public fun verify(publicKey: JWK, signedPayload: ByteArray, signature: ByteArray, algorithm: JWSAlgorithm? = null) {
-    val alg = publicKey.algorithm.toWeb5JWSAlgorithm() ?: algorithm
+  public fun verify(publicKey: JWK, signedPayload: ByteArray, signature: ByteArray, algorithm: Algorithm? = null) {
+    val alg = publicKey.algorithm.toWeb5Algorithm() ?: algorithm
     ?: throw IllegalArgumentException("Algorithm must either be set on JWK or provided explicitly.")
 
     val curve = getJwkCurve(publicKey)
@@ -167,7 +166,7 @@ public object Crypto {
    */
   public fun publicKeyToBytes(publicKey: JWK): ByteArray {
     val curve = getJwkCurve(publicKey)
-    val generator = getKeyGenerator(publicKey.algorithm.toWeb5JWSAlgorithm(), curve)
+    val generator = getKeyGenerator(publicKey.algorithm.toWeb5Algorithm(), curve)
 
     return generator.publicKeyToBytes(publicKey)
   }
@@ -183,7 +182,7 @@ public object Crypto {
    * @return The corresponding [KeyGenerator].
    * @throws IllegalArgumentException if the algorithm or curve is not supported.
    */
-  public fun getKeyGenerator(algorithm: JWSAlgorithm?, curve: Curve? = null): KeyGenerator {
+  public fun getKeyGenerator(algorithm: Algorithm?, curve: Curve? = null): KeyGenerator {
     return keyGenerators.getOrElse(Pair(algorithm, curve)) {
       throw IllegalArgumentException("Algorithm $algorithm not supported")
     }
@@ -216,7 +215,7 @@ public object Crypto {
    * @return The corresponding [Signer].
    * @throws IllegalArgumentException if the algorithm or curve is not supported.
    */
-  public fun getSigner(algorithm: JWSAlgorithm?, curve: Curve? = null): Signer {
+  public fun getSigner(algorithm: Algorithm?, curve: Curve? = null): Signer {
     return signers.getOrElse(Pair(algorithm, curve)) {
       throw IllegalArgumentException("Algorithm $algorithm not supported")
     }
@@ -233,7 +232,7 @@ public object Crypto {
    * @return The corresponding [Signer] capable of verification.
    * @throws IllegalArgumentException if the algorithm or curve is not supported.
    */
-  public fun getVerifier(algorithm: JWSAlgorithm, curve: Curve? = null): Signer {
+  public fun getVerifier(algorithm: Algorithm, curve: Curve? = null): Signer {
     return getSigner(algorithm, curve)
   }
 
@@ -260,7 +259,7 @@ public object Crypto {
    * Multicodec identifiers are useful for encoding the format or type of the key in systems that
    * leverage multiple cryptographic standards.
    *
-   * @param algorithm The cryptographic [JWSAlgorithm] for which the multicodec is requested.
+   * @param algorithm The cryptographic [Algorithm] for which the multicodec is requested.
    * @param curve The cryptographic [Curve] associated with the algorithm, or null if not applicable.
    * @return The multicodec identifier as an [Int] if a mapping exists, or null if the algorithm and curve
    *         combination is not supported or mapped.
@@ -270,14 +269,14 @@ public object Crypto {
    * val multicodec = getAlgorithmMultiCodec(JWSAlgorithm.EdDSA, Curve.Ed25519)
    * ```
    */
-  public fun getAlgorithmMultiCodec(algorithm: JWSAlgorithm, curve: Curve?): Int? {
+  public fun getAlgorithmMultiCodec(algorithm: Algorithm, curve: Curve?): Int? {
     return multiCodecsByAlgorithm[Pair(algorithm, curve)]
   }
 }
 
 /**
- * Converts a [Algorithm] from the nimbuds library to a [JWSAlgorithm].
+ * Converts an [Algorithm] from the nimbusds library to a [Algorithm].
  */
-public fun Algorithm?.toWeb5JWSAlgorithm(): JWSAlgorithm? {
-  return this?.name?.let { JWSAlgorithm.valueOf(it) }
+public fun com.nimbusds.jose.Algorithm?.toWeb5Algorithm(): Algorithm? {
+  return this?.name?.let { Algorithm.valueOf(it) }
 }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt
@@ -272,10 +272,3 @@ public object Crypto {
     return multiCodecsByAlgorithm[Pair(algorithm, curve)]
   }
 }
-
-/**
- * Converts an [Algorithm] from the nimbusds library to a [Algorithm].
- */
-public fun com.nimbusds.jose.Algorithm?.toWeb5Algorithm(): Algorithm? {
-  return this?.name?.let { Algorithm.valueOf(it) }
-}

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Curve.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Curve.kt
@@ -1,0 +1,31 @@
+package web5.sdk.crypto
+
+/**
+ * Represents a cryptographic curve.
+ */
+public enum class Curve(public val ianaName: String) {
+  SECP256K1("secp256k1"),
+  Ed25519("Ed25519");
+
+  internal fun toNimbusdsCurve(): com.nimbusds.jose.jwk.Curve? {
+    return when (this) {
+      SECP256K1 -> com.nimbusds.jose.jwk.Curve.SECP256K1
+      Ed25519 -> com.nimbusds.jose.jwk.Curve.Ed25519
+    }
+  }
+
+  public companion object {
+    private val ianaNames = Curve.entries.associateBy { it.ianaName }
+
+    /**
+     * Parses a curve name and returns the corresponding [Curve] object.
+     *
+     * @param ianaName The curve name as specified in https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
+     * @return The corresponding [Curve] object, or null if the curve name is invalid.
+     */
+    public fun parse(ianaName: String): Curve? {
+      return ianaNames[ianaName]
+    }
+  }
+
+}

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Curve.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Curve.kt
@@ -18,10 +18,9 @@ public enum class Curve(public val ianaName: String) {
     private val ianaNames = Curve.entries.associateBy { it.ianaName }
 
     /**
-     * Parses a curve name and returns the corresponding [Curve] object.
-     *
-     * @param ianaName The curve name as specified in https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
-     * @return The corresponding [Curve] object, or null if the curve name is invalid.
+     * Returns a [Curve] object given it's [ianaName]. The [ianaName] is how the curve was registered in the IANA table
+     * available at https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve. When there is no Curve for
+     * the given [ianaName], null is returned.
      */
     public fun parse(ianaName: String): Curve? {
       return ianaNames[ianaName]

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -2,6 +2,7 @@ package web5.sdk.crypto
 
 import com.google.crypto.tink.subtle.Ed25519Sign
 import com.google.crypto.tink.subtle.Ed25519Verify
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
@@ -34,7 +35,7 @@ import java.security.SignatureException
  */
 
 public object Ed25519 : KeyGenerator, Signer {
-  override val algorithm: JWSAlgorithm = JWSAlgorithm.EdDSA
+  override val algorithm: Algorithm = Algorithm.EdDSA
   override val keyType: KeyType = KeyType.OKP
 
   public const val PUB_MULTICODEC: Int = 0xed
@@ -48,7 +49,7 @@ public object Ed25519 : KeyGenerator, Signer {
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
     return OctetKeyPairGenerator(Curve.Ed25519)
-      .algorithm(JWSAlgorithm.EdDSA.toJwsAlgorithm())
+      .algorithm(JWSAlgorithm.EdDSA)
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
       .generate()
@@ -87,7 +88,7 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
     return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm.toJwsAlgorithm())
+      .algorithm(algorithm.toNimbusdsJWSAlgorithm())
       .keyIDFromThumbprint()
       .d(Base64URL(base64UrlEncodedPrivateKey))
       .keyUse(KeyUse.SIGNATURE)
@@ -98,7 +99,7 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
     return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm.toJwsAlgorithm())
+      .algorithm(algorithm.toNimbusdsJWSAlgorithm())
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -2,8 +2,6 @@ package web5.sdk.crypto
 
 import com.google.crypto.tink.subtle.Ed25519Sign
 import com.google.crypto.tink.subtle.Ed25519Verify
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
@@ -36,7 +34,7 @@ import java.security.SignatureException
  */
 
 public object Ed25519 : KeyGenerator, Signer {
-  override val algorithm: Algorithm = JWSAlgorithm.EdDSA
+  override val algorithm: JWSAlgorithm = JWSAlgorithm.EdDSA
   override val keyType: KeyType = KeyType.OKP
 
   public const val PUB_MULTICODEC: Int = 0xed
@@ -50,7 +48,7 @@ public object Ed25519 : KeyGenerator, Signer {
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
     return OctetKeyPairGenerator(Curve.Ed25519)
-      .algorithm(JWSAlgorithm.EdDSA)
+      .algorithm(JWSAlgorithm.EdDSA.toJwsAlgorithm())
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
       .generate()
@@ -89,7 +87,7 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
     return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm)
+      .algorithm(algorithm.toJwsAlgorithm())
       .keyIDFromThumbprint()
       .d(Base64URL(base64UrlEncodedPrivateKey))
       .keyUse(KeyUse.SIGNATURE)
@@ -100,7 +98,7 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
     return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm)
+      .algorithm(algorithm.toJwsAlgorithm())
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
 /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
@@ -38,7 +37,7 @@ public class InMemoryKeyManager : KeyManager {
    * @param options Options for key generation, may include specific parameters relevant to the algorithm.
    * @return The key ID of the generated private key.
    */
-  override fun generatePrivateKey(algorithm: Algorithm, curve: Curve?, options: KeyGenOptions?): String {
+  override fun generatePrivateKey(algorithm: JWSAlgorithm, curve: Curve?, options: KeyGenOptions?): String {
     val jwk = Crypto.generatePrivateKey(algorithm, curve, options)
     keyStore[jwk.keyID] = jwk
 

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -37,7 +37,7 @@ public class InMemoryKeyManager : KeyManager {
    * @param options Options for key generation, may include specific parameters relevant to the algorithm.
    * @return The key ID of the generated private key.
    */
-  override fun generatePrivateKey(algorithm: JWSAlgorithm, curve: Curve?, options: KeyGenOptions?): String {
+  override fun generatePrivateKey(algorithm: Algorithm, curve: Curve?, options: KeyGenOptions?): String {
     val jwk = Crypto.generatePrivateKey(algorithm, curve, options)
     keyStore[jwk.keyID] = jwk
 

--- a/crypto/src/main/kotlin/web5/sdk/crypto/JWSAlgorithm.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/JWSAlgorithm.kt
@@ -1,0 +1,19 @@
+package web5.sdk.crypto
+
+/**
+ * The supported JSON Web Signature algorithms.
+ */
+public enum class JWSAlgorithm {
+  /** ECDSA using secp256k1 curve and SHA-256. */
+  ES256K,
+
+  /** Edwards-curve Digital Signature Algorithm. */
+  EdDSA;
+
+  internal fun toJwsAlgorithm(): com.nimbusds.jose.JWSAlgorithm {
+    return when (this) {
+      ES256K -> com.nimbusds.jose.JWSAlgorithm.ES256K
+      EdDSA -> com.nimbusds.jose.JWSAlgorithm.EdDSA
+    }
+  }
+}

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
 
@@ -64,7 +63,7 @@ public interface KeyGenOptions
  */
 public interface KeyGenerator {
   /**  Indicates the algorithm intended to be used with the key. */
-  public val algorithm: Algorithm
+  public val algorithm: JWSAlgorithm
 
   /** Indicates the cryptographic algorithm family used with the key. */
   public val keyType: KeyType

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
@@ -63,7 +63,7 @@ public interface KeyGenOptions
  */
 public interface KeyGenerator {
   /**  Indicates the algorithm intended to be used with the key. */
-  public val algorithm: JWSAlgorithm
+  public val algorithm: Algorithm
 
   /** Indicates the cryptographic algorithm family used with the key. */
   public val keyType: KeyType

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -27,7 +27,7 @@ public interface KeyManager {
    * Implementations should ensure secure storage of the generated keys, protecting against
    * unauthorized access and ensuring cryptographic strength according to the provided parameters.
    */
-  public fun generatePrivateKey(algorithm: JWSAlgorithm, curve: Curve? = null, options: KeyGenOptions? = null): String
+  public fun generatePrivateKey(algorithm: Algorithm, curve: Curve? = null, options: KeyGenOptions? = null): String
 
   /**
    * Retrieves the public key associated with a previously stored private key, identified by the provided alias.

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
 /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
@@ -28,7 +27,7 @@ public interface KeyManager {
    * Implementations should ensure secure storage of the generated keys, protecting against
    * unauthorized access and ensuring cryptographic strength according to the provided parameters.
    */
-  public fun generatePrivateKey(algorithm: Algorithm, curve: Curve? = null, options: KeyGenOptions? = null): String
+  public fun generatePrivateKey(algorithm: JWSAlgorithm, curve: Curve? = null, options: KeyGenOptions? = null): String
 
   /**
    * Retrieves the public key associated with a previously stored private key, identified by the provided alias.

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -1,5 +1,6 @@
 package web5.sdk.crypto
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
@@ -59,7 +60,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     Security.addProvider(BouncyCastleProviderSingleton.getInstance())
   }
 
-  override val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K
+  override val algorithm: Algorithm = Algorithm.ES256K
   override val keyType: KeyType = KeyType.EC
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
@@ -139,7 +140,7 @@ public object Secp256k1 : KeyGenerator, Signer {
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
     return ECKeyGenerator(Curve.SECP256K1)
-      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
+      .algorithm(JWSAlgorithm.ES256K)
       .provider(BouncyCastleProviderSingleton.getInstance())
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
@@ -176,7 +177,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val rawY = pointQ.rawYCoord.encoded
 
     return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(rawX), Base64URL.encode(rawY))
-      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
+      .algorithm(JWSAlgorithm.ES256K)
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()
@@ -187,7 +188,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val yBytes = publicKeyBytes.sliceArray(33..64)
 
     return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(xBytes), Base64URL.encode(yBytes))
-      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
+      .algorithm(JWSAlgorithm.ES256K)
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -1,7 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
@@ -61,7 +59,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     Security.addProvider(BouncyCastleProviderSingleton.getInstance())
   }
 
-  override val algorithm: Algorithm = JWSAlgorithm.ES256K
+  override val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K
   override val keyType: KeyType = KeyType.EC
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
@@ -141,7 +139,7 @@ public object Secp256k1 : KeyGenerator, Signer {
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
     return ECKeyGenerator(Curve.SECP256K1)
-      .algorithm(JWSAlgorithm.ES256K)
+      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
       .provider(BouncyCastleProviderSingleton.getInstance())
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
@@ -178,7 +176,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val rawY = pointQ.rawYCoord.encoded
 
     return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(rawX), Base64URL.encode(rawY))
-      .algorithm(JWSAlgorithm.ES256K)
+      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()
@@ -189,7 +187,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val yBytes = publicKeyBytes.sliceArray(33..64)
 
     return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(xBytes), Base64URL.encode(yBytes))
-      .algorithm(JWSAlgorithm.ES256K)
+      .algorithm(JWSAlgorithm.ES256K.toJwsAlgorithm())
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()

--- a/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
@@ -4,7 +4,6 @@ import com.amazonaws.AmazonServiceException
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.kms.AWSKMSClient
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import org.junit.jupiter.api.Disabled
@@ -26,7 +25,7 @@ class AwsKeyManagerTest {
     assertEquals(alias, publicKey.keyID)
     assertEquals(KeyType.EC, publicKey.keyType)
     assertEquals(KeyUse.SIGNATURE, publicKey.keyUse)
-    assertEquals(JWSAlgorithm.ES256K, publicKey.algorithm)
+    assertEquals(JWSAlgorithm.ES256K.name, publicKey.algorithm.name)
   }
 
   @Test

--- a/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
@@ -19,20 +19,20 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test key generation`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Algorithm.ES256K)
     val publicKey = awsKeyManager.getPublicKey(alias)
 
     assertEquals(alias, publicKey.keyID)
     assertEquals(KeyType.EC, publicKey.keyType)
     assertEquals(KeyUse.SIGNATURE, publicKey.keyUse)
-    assertEquals(JWSAlgorithm.ES256K.name, publicKey.algorithm.name)
+    assertEquals(Algorithm.ES256K.name, publicKey.algorithm.name)
   }
 
   @Test
   @Disabled("Needs an AWS connection")
   fun `test alias is stable`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Algorithm.ES256K)
     val publicKey = awsKeyManager.getPublicKey(alias)
     val defaultAlias = awsKeyManager.getDeterministicAlias(publicKey)
 
@@ -43,7 +43,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test signing`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Algorithm.ES256K)
     val signature = awsKeyManager.sign(alias, signingInput)
 
     //Verify the signature with BouncyCastle via Crypto
@@ -63,7 +63,7 @@ class AwsKeyManagerTest {
     val customisedKeyManager = AwsKeyManager(kmsClient = kmsClient)
 
     assertThrows<AmazonServiceException> {
-      customisedKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+      customisedKeyManager.generatePrivateKey(Algorithm.ES256K)
     }
   }
 }

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -3,7 +3,6 @@ package web5.sdk.crypto
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -58,7 +57,9 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `key without kid can be imported`() {
-    val jwk = ECKeyGenerator(Curve.SECP256K1).provider(BouncyCastleProviderSingleton.getInstance()).generate()
+    val jwk = ECKeyGenerator(com.nimbusds.jose.jwk.Curve.SECP256K1)
+      .provider(BouncyCastleProviderSingleton.getInstance())
+      .generate()
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -18,7 +18,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `test alias is consistent`() {
     val keyManager = InMemoryKeyManager()
-    val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val publicKey = keyManager.getPublicKey(alias)
     val defaultAlias = keyManager.getDeterministicAlias(publicKey)
 
@@ -28,7 +28,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `exception is thrown when kid not found`() {
     val keyManager = InMemoryKeyManager()
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Algorithm.ES256K)
     val exception = assertThrows<IllegalArgumentException> {
       keyManager.getDeterministicAlias(jwk.toPublicJWK())
     }
@@ -37,7 +37,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public key is available after import`() {
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Algorithm.ES256K)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk)
@@ -48,7 +48,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public keys can be imported`() {
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Algorithm.ES256K)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk.toPublicJWK())
@@ -70,7 +70,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `export returns all keys`() {
     val keyManager = InMemoryKeyManager()
-    keyManager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+    keyManager.generatePrivateKey(Algorithm.EdDSA, Curve.Ed25519)
 
     val keySet = keyManager.export()
     assertEquals(1, keySet.size)

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -124,7 +124,7 @@ internal class DhtClient(
       val pubKey = manager.getPublicKey(keyAlias)
       require(
         pubKey.keyType == Ed25519.keyType &&
-          pubKey.algorithm == Ed25519.algorithm
+          pubKey.algorithm.name == Ed25519.algorithm.name
       ) {
         "Must supply an Ed25519 key"
       }
@@ -177,7 +177,7 @@ internal class DhtClient(
       val pubKey = manager.getPublicKey(keyAlias)
       require(
         pubKey.keyType == Ed25519.keyType &&
-          pubKey.algorithm == Ed25519.algorithm
+          pubKey.algorithm.name == Ed25519.algorithm.name
       ) {
         "Must supply an Ed25519 key"
       }

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DID
@@ -20,8 +19,10 @@ import web5.sdk.common.EncodingFormat
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.Ed25519
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
+import web5.sdk.crypto.toWeb5JWSAlgorithm
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidDocumentMetadata
@@ -333,7 +334,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
 
       verificationMethodsById[verificationMethod.id.toString()] = verificationMethodId
 
-      val keyType = when (publicKeyJwk.algorithm) {
+      val keyType = when (publicKeyJwk.algorithm.toWeb5JWSAlgorithm()) {
         JWSAlgorithm.EdDSA -> 0
         JWSAlgorithm.ES256K -> 1
         else -> throw IllegalArgumentException("unsupported algorithm: ${publicKeyJwk.algorithm}")

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
@@ -19,6 +18,7 @@ import web5.sdk.common.EncodingFormat
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -17,12 +17,12 @@ import org.xbill.DNS.TXTRecord
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
 import web5.sdk.common.ZBase32
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.Ed25519
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
-import web5.sdk.crypto.toWeb5JWSAlgorithm
+import web5.sdk.crypto.toWeb5Algorithm
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidDocumentMetadata
@@ -118,7 +118,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
     val opts = options ?: CreateDidDhtOptions()
 
     // create identity key
-    val keyAlias = keyManager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+    val keyAlias = keyManager.generatePrivateKey(Algorithm.EdDSA, Curve.Ed25519)
     val publicKey = keyManager.getPublicKey(keyAlias)
 
     // build DID Document
@@ -264,22 +264,24 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
   }
 
   override fun load(uri: String, keyManager: KeyManager): DidDht {
-      validateKeyMaterialInsideKeyManager(uri, keyManager)
-      validateIdentityKey(uri, keyManager)
-      return DidDht(uri, keyManager, null, this)
+    validateKeyMaterialInsideKeyManager(uri, keyManager)
+    validateIdentityKey(uri, keyManager)
+    return DidDht(uri, keyManager, null, this)
+  }
+
+  internal fun validateIdentityKey(did: String, keyManager: KeyManager) {
+    val parsedDid = DID.fromString(did)
+    val decodedId = ZBase32.decode(parsedDid.methodSpecificId)
+    require(decodedId.size == 32) {
+      "expected size of decoded identifier \"${parsedDid.methodSpecificId}\" to be 32"
     }
 
-    internal fun validateIdentityKey(did: String, keyManager: KeyManager) {
-      val parsedDid = DID.fromString(did)
-      val decodedId = ZBase32.decode(parsedDid.methodSpecificId)
-      require(decodedId.size == 32) {
-        "expected size of decoded identifier \"${parsedDid.methodSpecificId}\" to be 32"
-      }
+    val publicKeyJwk = Ed25519.bytesToPublicKey(decodedId)
+    val identityKeyAlias = keyManager.getDeterministicAlias(publicKeyJwk)
+    keyManager.getPublicKey(identityKeyAlias)
+  }
 
-      val publicKeyJwk = Ed25519.bytesToPublicKey(decodedId)
-      val identityKeyAlias = keyManager.getDeterministicAlias(publicKeyJwk)
-      keyManager.getPublicKey(identityKeyAlias)
-    }/**
+  /**
    * Generates the identifier for a did:dht DID given its identity key.
    *
    * @param identityKey the key used to generate the DID's identifier
@@ -334,9 +336,9 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
 
       verificationMethodsById[verificationMethod.id.toString()] = verificationMethodId
 
-      val keyType = when (publicKeyJwk.algorithm.toWeb5JWSAlgorithm()) {
-        JWSAlgorithm.EdDSA -> 0
-        JWSAlgorithm.ES256K -> 1
+      val keyType = when (publicKeyJwk.algorithm.toWeb5Algorithm()) {
+        Algorithm.EdDSA -> 0
+        Algorithm.ES256K -> 1
         else -> throw IllegalArgumentException("unsupported algorithm: ${publicKeyJwk.algorithm}")
       }
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.runBlocking
 import org.erdtman.jcs.JsonCanonicalizer
 import web5.sdk.common.Convert
 import web5.sdk.common.Varint
-import web5.sdk.crypto.JWSAlgorithm
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.KeyGenOptions
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions
@@ -356,7 +356,7 @@ public sealed class DidIonApi(
     }
     val updatePublicKey = keyManager.getPublicKey(options.updateKeyAlias)
 
-    val newUpdateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val newUpdateKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val newUpdatePublicKey = keyManager.getPublicKey(newUpdateKeyAlias)
 
     val reveal = updatePublicKey.reveal()
@@ -443,7 +443,7 @@ public sealed class DidIonApi(
 
   internal fun createOperation(keyManager: KeyManager, options: CreateDidIonOptions?)
     : Pair<SidetreeCreateOperation, KeyAliases> {
-    val updateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val updateKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val updatePublicJwk = keyManager.getPublicKey(updateKeyAlias)
 
     val publicKeyCommitment = updatePublicJwk.commitment()
@@ -459,7 +459,7 @@ public sealed class DidIonApi(
       updateCommitment = publicKeyCommitment
     )
 
-    val recoveryKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val recoveryKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val recoveryPublicJwk = keyManager.getPublicKey(recoveryKeyAlias)
     val recoveryCommitment = recoveryPublicJwk.commitment()
 
@@ -484,7 +484,7 @@ public sealed class DidIonApi(
     if (options == null || options.verificationMethodsToAdd.count() == 0) {
       listOf<VerificationMethodSpec>(
         VerificationMethodCreationParams(
-          JWSAlgorithm.ES256K,
+          Algorithm.ES256K,
           relationships = listOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD)
         )
       ).toPublicKeys(keyManager)
@@ -545,11 +545,11 @@ public sealed class DidIonApi(
     val recoveryPublicKey = keyManager.getPublicKey(options.recoveryKeyAlias)
     val reveal = recoveryPublicKey.reveal()
 
-    val nextRecoveryKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val nextRecoveryKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val nextRecoveryPublicKey = keyManager.getPublicKey(nextRecoveryKeyAlias)
     val nextRecoveryCommitment = nextRecoveryPublicKey.commitment()
 
-    val nextUpdateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val nextUpdateKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val nextUpdatePublicKey = keyManager.getPublicKey(nextUpdateKeyAlias)
     val nextUpdateCommitment = nextUpdatePublicKey.commitment()
 
@@ -803,7 +803,7 @@ private interface VerificationMethodGenerator {
  * [relationships] will be used to determine the verification relationships in the DID Document being created.
  * */
 public class VerificationMethodCreationParams(
-  public val algorithm: JWSAlgorithm,
+  public val algorithm: Algorithm,
   public val curve: Curve? = null,
   public val options: KeyGenOptions? = null,
   public val relationships: Iterable<PublicKeyPurpose>

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -1,8 +1,6 @@
 package web5.sdk.dids.methods.ion
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.Payload
@@ -27,6 +25,7 @@ import kotlinx.coroutines.runBlocking
 import org.erdtman.jcs.JsonCanonicalizer
 import web5.sdk.common.Convert
 import web5.sdk.common.Varint
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyGenOptions
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions
@@ -399,7 +398,7 @@ public sealed class DidIonApi(
   }
 
   private fun sign(serializableObject: Any, keyManager: KeyManager, signKeyAlias: String): JWSObject {
-    val header = JWSHeader.Builder(JWSAlgorithm.ES256K).build()
+    val header = JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.ES256K).build()
     val payload = Payload(mapper.writeValueAsString(serializableObject))
     val jwsObject = JWSObject(header, payload)
     val signatureBytes = keyManager.sign(signKeyAlias, jwsObject.signingInput)
@@ -804,7 +803,7 @@ private interface VerificationMethodGenerator {
  * [relationships] will be used to determine the verification relationships in the DID Document being created.
  * */
 public class VerificationMethodCreationParams(
-  public val algorithm: Algorithm,
+  public val algorithm: JWSAlgorithm,
   public val curve: Curve? = null,
   public val options: KeyGenOptions? = null,
   public val relationships: Iterable<PublicKeyPurpose>

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.Payload
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.util.Base64URL
 import foundation.identity.did.DID
@@ -26,6 +25,7 @@ import org.erdtman.jcs.JsonCanonicalizer
 import web5.sdk.common.Convert
 import web5.sdk.common.Varint
 import web5.sdk.crypto.Algorithm
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.KeyGenOptions
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -1,7 +1,5 @@
 package web5.sdk.dids.methods.jwk
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
@@ -10,6 +8,7 @@ import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
@@ -36,7 +35,7 @@ import java.net.URI
  * ```
  */
 public class CreateDidJwkOptions(
-  public val algorithm: Algorithm = JWSAlgorithm.ES256K,
+  public val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K,
   public val curve: Curve? = null
 ) : CreateDidOptions
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -8,7 +8,7 @@ import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
-import web5.sdk.crypto.JWSAlgorithm
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
@@ -35,7 +35,7 @@ import java.net.URI
  * ```
  */
 public class CreateDidJwkOptions(
-  public val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K,
+  public val algorithm: Algorithm = Algorithm.ES256K,
   public val curve: Curve? = null
 ) : CreateDidOptions
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.jwk
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
 import foundation.identity.did.DID
@@ -9,6 +8,7 @@ import foundation.identity.did.VerificationMethod
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
 import web5.sdk.crypto.Algorithm
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -1,7 +1,5 @@
 package web5.sdk.dids.methods.key
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
@@ -9,6 +7,7 @@ import foundation.identity.did.VerificationMethod
 import io.ipfs.multibase.Multibase
 import web5.sdk.common.Varint
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
 import web5.sdk.dids.CreateDidOptions
@@ -36,7 +35,7 @@ import java.net.URI
  * ```
  */
 public class CreateDidKeyOptions(
-  public val algorithm: Algorithm = JWSAlgorithm.ES256K,
+  public val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K,
   public val curve: Curve? = null
 ) : CreateDidOptions
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.key
 
-import com.nimbusds.jose.jwk.Curve
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
@@ -8,6 +7,7 @@ import io.ipfs.multibase.Multibase
 import web5.sdk.common.Varint
 import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
 import web5.sdk.dids.CreateDidOptions

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -6,8 +6,8 @@ import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
 import io.ipfs.multibase.Multibase
 import web5.sdk.common.Varint
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.Crypto
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
 import web5.sdk.dids.CreateDidOptions
@@ -35,7 +35,7 @@ import java.net.URI
  * ```
  */
 public class CreateDidKeyOptions(
-  public val algorithm: JWSAlgorithm = JWSAlgorithm.ES256K,
+  public val algorithm: Algorithm = Algorithm.ES256K,
   public val curve: Curve? = null
 ) : CreateDidOptions
 
@@ -89,7 +89,7 @@ public class DidKey private constructor(uri: String, keyManager: KeyManager) : D
       val publicKey = keyManager.getPublicKey(keyAlias)
       var publicKeyBytes = Crypto.publicKeyToBytes(publicKey)
 
-      if (opts.algorithm == JWSAlgorithm.ES256K) {
+      if (opts.algorithm == Algorithm.ES256K) {
         publicKeyBytes = Secp256k1.compressPublicKey(publicKeyBytes)
       }
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
@@ -1,25 +1,20 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.jwk.Curve
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.headersOf
-import io.ktor.utils.io.ByteReadChannel
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Secp256k1
-import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.text.hexToByteArray
 
 class DhtTest {
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.Service
 import foundation.identity.did.parser.ParserException
@@ -14,6 +13,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Algorithm
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.PublicKeyPurpose
 import java.net.URI

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.Service
@@ -9,13 +8,13 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import io.ktor.util.hex
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.PublicKeyPurpose
 import java.net.URI
 import kotlin.test.assertContains

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.ZBase32
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.PublicKeyPurpose
 import java.net.URI
 import kotlin.test.assertContains
@@ -28,7 +28,7 @@ class DidDhtTest {
     @Test
     fun `did dht identifier`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Algorithm.EdDSA, Curve.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
 
       val identifier = DidDht.getDidIdentifier(publicKey)
@@ -42,7 +42,7 @@ class DidDhtTest {
     @Test
     fun `validate identity key`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Algorithm.EdDSA, Curve.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
       val identifier = DidDht.getDidIdentifier(publicKey)
 
@@ -100,7 +100,7 @@ class DidDhtTest {
     fun `create with another key and service`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(JWSAlgorithm.ES256K, Curve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(Algorithm.ES256K, Curve.SECP256K1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val verificationMethodsToAdd: Iterable<Pair<JWK, Array<PublicKeyPurpose>>> = listOf(
         Pair(publicKeyJwk, arrayOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD))
@@ -249,7 +249,7 @@ class DidDhtTest {
     fun `to and from DNS packet - complex DID`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(JWSAlgorithm.ES256K, Curve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(Algorithm.ES256K, Curve.SECP256K1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val verificationMethodsToAdd: Iterable<Pair<JWK, Array<PublicKeyPurpose>>> = listOf(
         Pair(publicKeyJwk, arrayOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD))

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service
@@ -167,11 +167,11 @@ class DidIonTest {
     val verificationKey = readKey("src/test/resources/verification_jwk.json")
     val updateKey = readKey("src/test/resources/update_jwk.json")
     val updateKeyId = keyManager.import(updateKey)
-    doReturn(updateKeyId).whenever(keyManager).generatePrivateKey(JWSAlgorithm.ES256K)
+    doReturn(updateKeyId).whenever(keyManager).generatePrivateKey(Algorithm.ES256K)
 
     val recoveryKey = readKey("src/test/resources/recovery_jwk.json")
     val recoveryKeyId = keyManager.import(recoveryKey)
-    doReturn(recoveryKeyId).whenever(keyManager).generatePrivateKey(JWSAlgorithm.ES256K)
+    doReturn(recoveryKeyId).whenever(keyManager).generatePrivateKey(Algorithm.ES256K)
 
     val didIonApi = DidIonApi {
       ionHost = "madeuphost"
@@ -224,11 +224,11 @@ class DidIonTest {
       keyManager, CreateDidIonOptions(
       verificationMethodsToAdd = listOf(
         VerificationMethodCreationParams(
-          JWSAlgorithm.ES256K,
+          Algorithm.ES256K,
           relationships = listOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD)
         ),
         VerificationMethodCreationParams(
-          JWSAlgorithm.ES256K,
+          Algorithm.ES256K,
           relationships = listOf(PublicKeyPurpose.ASSERTION_METHOD)
         ),
       )
@@ -249,10 +249,10 @@ class DidIonTest {
   @Test
   fun `update throws exception when given invalid input`() {
     val keyManager = InMemoryKeyManager()
-    val keyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val keyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
     val publicKey = keyManager.getPublicKey(keyAlias)
 
-    val updateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val updateKeyAlias = keyManager.generatePrivateKey(Algorithm.ES256K)
 
     class TestCase(
       val services: Iterable<Service> = emptyList(),
@@ -350,7 +350,7 @@ class DidIonTest {
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k2Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
 
-    doReturn(nextUpdateKeyId, recoveryKeyAlias).whenever(keyManager).generatePrivateKey(JWSAlgorithm.ES256K)
+    doReturn(nextUpdateKeyId, recoveryKeyAlias).whenever(keyManager).generatePrivateKey(Algorithm.ES256K)
 
     val (result, _) = DidIon.createOperation(
       keyManager,
@@ -390,7 +390,7 @@ class DidIonTest {
 
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k2Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
-    doReturn(nextUpdateKeyId).whenever(keyManager).generatePrivateKey(JWSAlgorithm.ES256K)
+    doReturn(nextUpdateKeyId).whenever(keyManager).generatePrivateKey(Algorithm.ES256K)
 
     val service: Service = mapper.readValue(File("src/test/resources/service1.json").readText())
     val publicKey1 = publicKey1VerificationMethod(mapper)
@@ -450,7 +450,7 @@ class DidIonTest {
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k3Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
 
-    doReturn(nextRecoveryKeyId, nextUpdateKeyId).whenever(keyManager).generatePrivateKey(JWSAlgorithm.ES256K)
+    doReturn(nextRecoveryKeyId, nextUpdateKeyId).whenever(keyManager).generatePrivateKey(Algorithm.ES256K)
 
     val (recoverOperation, keyAliases) = DidIon.createRecoverOperation(
       keyManager,

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -3,7 +3,6 @@ package web5.sdk.dids.methods.ion
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.nimbusds.jose.JWSAlgorithm
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
@@ -22,6 +21,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
+import web5.sdk.crypto.Algorithm
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.DidResolvers
 import java.io.File
 import kotlin.test.assertEquals
@@ -31,7 +31,7 @@ class DidJwkTest {
       val keyAlias = did.keyManager.getDeterministicAlias(jwk)
       val publicKey = did.keyManager.getPublicKey(keyAlias)
 
-      assertEquals(JWSAlgorithm.ES256K.name, publicKey.algorithm.name)
+      assertEquals(Algorithm.ES256K.name, publicKey.algorithm.name)
     }
   }
 
@@ -74,7 +74,7 @@ class DidJwkTest {
     @Test
     fun `private key throws exception`() {
       val manager = InMemoryKeyManager()
-      manager.generatePrivateKey(JWSAlgorithm.ES256K)
+      manager.generatePrivateKey(Algorithm.ES256K)
       val privateJwk = JWK.parse(manager.export().first())
       val encodedPrivateJwk = Convert(privateJwk.toJSONString()).toBase64Url(padding = false)
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.jwk
 
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWK
 import org.erdtman.jcs.JsonCanonicalizer
 import org.junit.jupiter.api.Nested
@@ -8,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.JWSAlgorithm
 import web5.sdk.dids.DidResolvers
 import java.io.File
 import kotlin.test.assertEquals
@@ -31,7 +31,7 @@ class DidJwkTest {
       val keyAlias = did.keyManager.getDeterministicAlias(jwk)
       val publicKey = did.keyManager.getPublicKey(keyAlias)
 
-      assertEquals(JWSAlgorithm.ES256K, publicKey.algorithm)
+      assertEquals(JWSAlgorithm.ES256K.name, publicKey.algorithm.name)
     }
   }
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/key/DidKeyTest.kt
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.Curve
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.DidResolvers
 import kotlin.test.assertEquals
@@ -100,7 +100,7 @@ class DidKeyTest {
       assertTrue(publicKeyJwk is ECKey)
 
       assertEquals(publicKeyJwk.algorithm, JWSAlgorithm.ES256K)
-      assertEquals(Curve.SECP256K1, publicKeyJwk.curve)
+      assertEquals(Curve.SECP256K1.ianaName, publicKeyJwk.curve.name)
       assertEquals("TEIJN9vnTq1EXMkqzo7yN_867-foKc2pREv45Fw_QA8", publicKeyJwk.x.toString())
       assertEquals("9yiymlzdxKCiRbYq7p-ArRB-C1ytjHE-eb7RDTi6rVc", publicKeyJwk.y.toString())
 


### PR DESCRIPTION
# Overview
This PR addresses #110 by introducing our own enums. 

# Description

Note that there are some cases in which the `nimbusds` classes are used. This is intentional, because the tests are actually already using it to create JWKs or JWTs directly.  The public API of the introduced enums is details below. 

## Public APIs

### Curve

```kt
/**
 * Returns a [Curve] object given it's [ianaName]. The [ianaName] is how the curve was registered in the IANA table
 * available at https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve. When there is no Curve for
 * the given [ianaName], null is returned.
 */
public fun parse(ianaName: String): Curve?
```

Usage example:
```kt
val curve = Curve.parse("secp256k1")
assertEquals(Curve.SECP256K1, curve)

val nullCurve = Curve.pase("magicCurve")
assertNull(nullCurve)
```

### Algorithm

```kt
/**
 * Converts an [Algorithm] from the nimbusds library to a [Algorithm].
 */
public fun com.nimbusds.jose.Algorithm?.toWeb5Algorithm(): Algorithm?
```

This is useful when consumers have a nimbusds type, like what would represent a jwt, and want to be able to call our libraries.

 Usage example:
```kt
// Assume publicKeyJwk, toVerifyBytes, signatureBytes are all given already
val jwt = JWTParser.parse(vcJwt) as SignedJWT
Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm.toWeb5Algorithm())
```


# How Has This Been Tested?
This is refactoring, so unit tests already covered the changes.
