### PR TITLE
Adding publishing to Central Repository using a github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish'
+        description: 'Version to publish. For example "0.0.1"'
         required: true
         default: '0.0.0'
   push:
     tags:
       - v*
-    branches:
-      - issue_68
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,11 +17,14 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
+          distribution: 'corretto'
           java-version: '11'
-          distribution: 'adopt'
-      - name: Run chmod to make gradlew executable
-        run: chmod +x ./gradlew
-      - name: Publish package to local staging directory
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: gradle-ubuntu-latest-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}
+
+      - name: Publish packages to sonatype staging
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             ./gradlew -Pversion=${{ github.event.inputs.version }} :publishToSonatype :closeSonatypeStagingRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
             ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) :publishToSonatype :closeSonatypeStagingRepository
           fi
         env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_sonatypeUsername }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_sonatypePassword }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEUSERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPEPASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,16 @@
 name: Publish package to the Maven Central Repository
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+        default: '0.0.0'
   push:
     tags:
       - v*
     branches:
       - issue_68
-  pull_request:
-    branches: [ main ]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -20,24 +24,14 @@ jobs:
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
       - name: Publish package to local staging directory
-        run: ./gradlew :publish
-      - name: Publish package to maven central
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            ./gradlew -Pversion=${{ github.event.inputs.version }} :publishToSonatype :closeSonatypeStagingRepository
+          else
+            ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) :publishToSonatype :closeSonatypeStagingRepository
+          fi
         env:
-          JRELEASER_NEXUS2_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
-          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew :jreleaserDeploy -DaltDeploymentRepository=local::file:./build/staging-deploy
-
-          # Persist logs
-
-      - name: JReleaser release output
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: jreleaser-release
-          path: |
-            out/jreleaser/trace.log
-            out/jreleaser/output.properties
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_sonatypeUsername }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_sonatypePassword }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish package to the Maven Central Repository
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - issue_68
+  pull_request:
+    branches: [ main ]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Run chmod to make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Publish package to local staging directory
+        run: ./gradlew :publish
+      - name: Publish package to maven central
+        env:
+          JRELEASER_NEXUS2_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
+          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :jreleaserDeploy -DaltDeploymentRepository=local::file:./build/staging-deploy
+
+          # Persist logs
+
+      - name: JReleaser release output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-release
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,8 @@ on:
         description: 'Version to publish. For example "0.0.1"'
         required: true
         default: '0.0.0'
-  push:
-    tags:
-      - v*
+  release:
+    types: [ published ]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
           key: gradle-ubuntu-latest-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}
 
       - name: Publish packages to sonatype staging
+        # TODO: Change to closeAndReleaseSonatypeStagingRepository once we are confident that the workflow works as expected.
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             ./gradlew -Pversion=${{ github.event.inputs.version }} :publishToSonatype :closeSonatypeStagingRepository

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### EnvFiles ###
+*.env

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ package from Maven Central. The second is pulling the package from JitPack.
 ## Maven Central
 
 When pulling from Maven Central, you can pull the entire library or just a single module. Examples of both are shown
-below. Please note that you need to add the repositories shows below to your `build.gradle.kts` file. This is because
-the libraries that we depend on are hosted in places
+below. Please note that you need to add the repositories shown below to your `build.gradle.kts` file. This is because
+the libraries that we depend on are hosted in separate places.
 
 ```kt
 repositories {

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ the libraries that we depend on are hosted in places
 
 ```kt
 repositories {
+  mavenCentral()
   maven("https://jitpack.io")
   maven("https://repo.danubetech.com/repository/maven-public/")
   maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
@@ -48,6 +49,7 @@ You can also pull the jars for this library from [JitPack](https://jitpack.io). 
 
 ```kotlin
 repositories {
+  mavenCentral()
   maven("https://jitpack.io")
   maven("https://repo.danubetech.com/repository/maven-public/")
   maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")

--- a/README.md
+++ b/README.md
@@ -13,8 +13,38 @@ This repo contains 4 jvm packages:
 
 # Quickstart
 
-All the web5 libraries are published on [JitPack](https://jitpack.io). To start simply add the following to your
-`gradle.build.kts` file:
+You can add this library you your project using Gradle or Maven. There are two ways to do so. The first is pulling the
+package from Maven Central. The second is pulling the package from JitPack.
+
+## Maven Central
+
+When pulling from Maven Central, you can pull the entire library or just a single module. Examples of both are shown
+below. Please note that you need to add the repositories shows below to your `build.gradle.kts` file. This is because
+the libraries that we depend on are hosted in places
+
+```kt
+repositories {
+  maven("https://jitpack.io")
+  maven("https://repo.danubetech.com/repository/maven-public/")
+  maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
+}
+  
+dependencies {
+  // If you want to pull the entire library
+  implementation("xyz.block:web5:0.1.0")
+  
+  // If you want to pull a single module
+  implementation("xyz.block:web5-common:0.1.0")
+  implementation("xyz.block:web5-credentials:0.1.0")
+  implementation("xyz.block:web5-crypto:0.1.0")
+  implementation("xyz.block:web5-dids:0.1.0")
+}
+```
+
+## JitPack
+
+You can also pull the jars for this library from [JitPack](https://jitpack.io). To start simply add the following to your
+`build.gradle.kts` file:
 
 ```kotlin
 repositories {

--- a/README.md
+++ b/README.md
@@ -52,11 +52,43 @@ in [GitHub Pages](https://tbd54566975.github.io/web5-kt/docs/htmlMultiModule/cre
 
 # Development
 
+## Prerequisites
+
+Install java version 11. If you're installing a higher version, it must be compatible with Gradle 8.2.
+
+If you want to have multiple version of Java installed in your machine, we recommend using [jenv](https://www.jenv.be/).
+
+> [!NOTE]: Restart your shell after installation.
+
+## Build
+
 To build and run test just run:
 
 ```bash
 ./gradlew build --console=rich
 ```
+
+## Releasing
+
+In order to release to Central Repository, simply cut a new release tag in the Github UI. There is a configured [Github
+Action](./.github/workflows/publish.yml) that will automatically publish the release to Central Repository. You can cut
+the release by going to the [create a new releases page](https://github.com/TBD54566975/web5-kt/releases/new). When
+creating a new tag, the name should be in the format `vX.Y.Z`. Please note that once a release is made, it is immutable
+and cannot be deleted.
+
+### Manual Release
+
+If you want to do a manual release, you have two options:
+1. Dispatch the [publish workflow](./.github/workflows/publish.yml) workflow from the Github UI. Go to the [publish 
+   Actions](https://github.com/TBD54566975/web5-kt/actions) > "Run workflow". 
+2. Setup your local environment to publish to Central Repository. This is more involved. You'll need to:
+   1. Define all the environment variables described in the [publish workflow](./.github/workflows/publish.yml) file. You
+      can find the values in the [secrets and variable](https://github.com/TBD54566975/web5-kt/settings/secrets/actions)
+      page.
+   2. Run the following command (you can change `samplebranch` to any branch name):
+      ```bash
+      ./gradlew -Pversion=samplebranch-SNAPSHOT publishToSonatype closeAndReleaseSonatypeStagingRepository
+      ```
 
 # Other Docs
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo contains 4 jvm packages:
 
 # Quickstart
 
-You can add this library you your project using Gradle or Maven. There are two ways to do so. The first is pulling the
+You can add this library to your project using Gradle or Maven. There are two ways to do so. The first is pulling the
 package from Maven Central. The second is pulling the package from JitPack.
 
 ## Maven Central

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,8 +160,8 @@ subprojects {
     }
 
     signing {
-      val signingKey: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
-      val signingPassword: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
+      val signingKey: String? by project
+      val signingPassword: String? by project
       useInMemoryPgpKeys(signingKey, signingPassword)
       sign(publishing.publications[publicationName])
     }
@@ -245,10 +245,10 @@ publishing {
 }
 
 signing {
-  val signingKey: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
-  val signingPassword: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
+  val signingKey: String? by project
+  val signingPassword: String? by project
   useInMemoryPgpKeys(signingKey, signingPassword)
-  sign(publishing.publications[name])
+  sign(publishing.publications["web5"])
 }
 
 nexusPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,10 @@ repositories {
 }
 
 dependencies {
-  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
+  api(project(":common"))
+  api(project(":credentials"))
+  api(project(":crypto"))
+  api(project(":dids"))
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,8 +160,8 @@ subprojects {
     }
 
     signing {
-      val signingKey: String? by project
-      val signingPassword: String? by project
+      val signingKey: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
+      val signingPassword: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
       useInMemoryPgpKeys(signingKey, signingPassword)
       sign(publishing.publications[publicationName])
     }
@@ -245,10 +245,10 @@ publishing {
 }
 
 signing {
-  val signingKey: String? by project
-  val signingPassword: String? by project
+  val signingKey: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGKEY")
+  val signingPassword: String? = System.getenv("ORG_GRADLE_PROJECT_SIGNINGPASSWORD")
   useInMemoryPgpKeys(signingKey, signingPassword)
-  sign(publishing.publications["web5"])
+  sign(publishing.publications[name])
 }
 
 nexusPublishing {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -11,15 +11,3 @@ dependencies {
   testImplementation(kotlin("test"))
   testImplementation(project(mapOf("path" to ":crypto")))
 }
-
-java {
-  withJavadocJar()
-  withSourcesJar()
-}
-
-//mavenPublishing {
-//  configure(KotlinJvm(
-//    sourcesJar = true,
-//    javadocJar = JavadocJar.Javadoc()
-//  ))
-//}


### PR DESCRIPTION
# Overview

This PR fixes #68, fixes #126, and fixes #128 by configuring gradle, the repo, and a CI action to publish the libraries from this repo to maven central. 

# Description

This PR includes. 
* Updates to the README file on how to import this library, and how to realease it. The current `groupId` we've settled on is `xyz.block`, but that's likely to change (see the convo at https://github.com/TBD54566975/open-source-programs/issues/95). When the time comes, we'll update it. Alternatively, we can delay this PR until that's ready.
* Adding a `publish.yml` file. This workflow will trigger when a new release is cut. It will release the version specified to maven central. See the README updates for more details. 
* Changes to gradle file such that:
    * All submodules are included in the root module, importable as `web5`.
    * Publications now include details of the POM file.
    * Publications will be signed using a PGP key. (note that I created the key previously by following the instructions in https://central.sonatype.org/publish/requirements/gpg/#credentials).

# How Has This Been Tested?

I tested the CI action by making sure that you can import `xyz.block:web5:test-SNAPSHOT` from a separate repo. Additionally, the jar's can be seen from https://s01.oss.sonatype.org/#welcome, after logging in as `tbd-releases` (the password is in the shared 1password vault).

All the commands in the README were tested as well to behave as expected.

## References
* The main guide: https://central.sonatype.org/publish/publish-gradle/
* And the README of the gradle plugin used: https://github.com/Codearte/gradle-nexus-staging-plugin/#quick-start
