### PR TITLE
Adding test publishing to BuildKite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,40 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: ${{ runner.os }}
+
+      - name: Publish Tests Results
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+        run: |
+          declare -a projects=("common" "credentials" "crypto" "dids")
+          
+          for project in "${projects[@]}"; do
+            # Find Tests Reports in each project and store them in an array
+            files=($(find "${project}/build/test-results/test" -name '*.xml'))
+          
+            # Check if files array is empty
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "No Tests files found in ${project} directory!"
+              exit 1
+            else
+              echo "Found ${#files[@]} XML files in ${project} directory, proceeding with upload..."
+            fi
+
+            # Iterate over the files and upload each one
+            for file in "${files[@]}"; do
+                echo "Uploading ${file} to BuildKite..."
+                curl \
+                  -X POST \
+                  --fail-with-body \
+                  -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+                  -F "data=@$file" \
+                  -F "format=junit" \
+                  -F "run_env[CI]=github_actions" \
+                  -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+                  -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+                  -F "run_env[branch]=$GITHUB_REF" \
+                  -F "run_env[commit_sha]=$GITHUB_SHA" \
+                  -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+                  https://analytics-api.buildkite.com/v1/uploads
+            done
+          done


### PR DESCRIPTION
# Overview
Fixes #123 by adding a publishing step to buildkite during CI. 

# Description
See original issue for motivation. The implementations is the same as in https://github.com/TBD54566975/tbdex-kt/pull/102

The secret `BUILDKITE_ANALYTICS_TOKEN` was set up within the repo.

# How Has This Been Tested?

See https://buildkite.com/organizations/tbd-oss/analytics/suites/web5-kt/runs/7fb7c7ae-6a2a-4099-a49b-15190ce9490c for a sample result.

