### PR TITLE
Fix gradle publishing typo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,9 @@ jobs:
         # TODO: Change to closeAndReleaseSonatypeStagingRepository once we are confident that the workflow works as expected.
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
-            ./gradlew -Pversion=${{ github.event.inputs.version }} :publishToSonatype :closeSonatypeStagingRepository
+            ./gradlew -Pversion=${{ github.event.inputs.version }} publishToSonatype closeSonatypeStagingRepository
           else
-            ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) :publishToSonatype :closeSonatypeStagingRepository
+            ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) publishToSonatype closeSonatypeStagingRepository
           fi
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}


### PR DESCRIPTION
This PR makes sure that all modules are published to Sonatype. Below, the answer of an AI to the question: what's the difference when running a gradle task prefixed with : , and without the prefix?

> When running a Gradle task, the prefix : is used to specify the project path. The difference between running a task with and without the prefix is as follows:
> 1. Running a task without the prefix: When you run a task without the prefix, Gradle will execute the task in the current project. For example, if you are in the root project directory and run gradle clean, it will execute the clean task in the current project.
> 2. Running a task with the prefix: When you run a task with the prefix :, Gradle will execute the task in the specified project. The prefix : is used to specify the project path relative to the root project. For example, if you have a subproject named app and you run gradle :app:clean, it will execute the clean task in the app subproject.
> In summary, the prefix : is used to specify the project path when running a Gradle task. Without the prefix, the task is executed in the current project, and with the prefix, the task is executed in the specified project.