### PR TITLE
Add release to the publishing step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           path: ~/.gradle/caches
           key: gradle-ubuntu-latest-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}
 
-      - name: Publish packages to sonatype staging
+      - name: Sonatype Publish Close And Release
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             ./gradlew -Pversion=${{ github.event.inputs.version }} publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
@@ -24,12 +23,11 @@ jobs:
           key: gradle-ubuntu-latest-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/versions.properties') }}
 
       - name: Publish packages to sonatype staging
-        # TODO: Change to closeAndReleaseSonatypeStagingRepository once we are confident that the workflow works as expected.
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
-            ./gradlew -Pversion=${{ github.event.inputs.version }} publishToSonatype closeSonatypeStagingRepository
+            ./gradlew -Pversion=${{ github.event.inputs.version }} publishToSonatype closeAndReleaseSonatypeStagingRepository
           else
-            ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) publishToSonatype closeSonatypeStagingRepository
+            ./gradlew -Pversion=$(echo "${{ github.ref_name }}" | cut -c2-) publishToSonatype closeAndReleaseSonatypeStagingRepository
           fi
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}


### PR DESCRIPTION
This change updates a step in the publish workflow so that the package in sonatype is released. Once released, it is immutable and available for the worlds to consume. 

Currently, the steps to release include:
1. Cut a release, which published to sonatype staging automatically by running the action https://github.com/TBD54566975/web5-kt/actions/runs/7198920796.
2. Click the "Release" button in https://s01.oss.sonatype.org/#stagingRepositories

This change removes the need of clicking the button in (2). 
