### PR TITLE
Remove adding dep using jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # web5-sdk-kotlin
 
 [![License](https://img.shields.io/github/license/TBD54566975/web5-kt)](https://github.com/TBD54566975/web5-kt/blob/main/LICENSE)
- [![SDK Kotlin CI](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml/badge.svg)](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/codecov/c/gh/tbd54566975/web5-kt/main?logo=codecov&logoColor=FFFFFF&style=flat-square&token=YI87CKF1LI)](https://codecov.io/github/TBD54566975/web5-kt)
-
+[![SDK Kotlin CI](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml/badge.svg)](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/codecov/c/gh/tbd54566975/web5-kt/main?logo=codecov&logoColor=FFFFFF&style=flat-square&token=YI87CKF1LI)](https://codecov.io/github/TBD54566975/web5-kt)
 
 This repo contains 4 jvm packages:
 
@@ -13,8 +12,7 @@ This repo contains 4 jvm packages:
 
 # Quickstart
 
-You can add this library to your project using Gradle or Maven. There are two ways to do so. The first is pulling the
-package from Maven Central. The second is pulling the package from JitPack.
+You can add this library to your project using Gradle or Maven. To do so, pull the package from Maven Central.
 
 ## Maven Central
 
@@ -29,11 +27,11 @@ repositories {
   maven("https://repo.danubetech.com/repository/maven-public/")
   maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
-  
+
 dependencies {
   // If you want to pull the entire library
   implementation("xyz.block:web5:0.1.0")
-  
+
   // If you want to pull a single module
   implementation("xyz.block:web5-common:0.1.0")
   implementation("xyz.block:web5-credentials:0.1.0")
@@ -42,40 +40,9 @@ dependencies {
 }
 ```
 
-## JitPack
-
-You can also pull the jars for this library from [JitPack](https://jitpack.io). To start simply add the following to your
-`build.gradle.kts` file:
-
-```kotlin
-repositories {
-  mavenCentral()
-  maven("https://jitpack.io")
-  maven("https://repo.danubetech.com/repository/maven-public/")
-  maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
-}
-
-dependencies {
-  implementation("com.github.TBD54566975:web5-kt:main-SNAPSHOT")
-}
-```
-
 > [!IMPORTANT]
-> The repository at `https://repo.danubetech.com/repository/maven-public/` is required for resolving transitive
-dependencies.
-
-If you want to refer to a specific release, then replace the `main-SNAPSHOT` with release tag.
-
-If you want to pull a PR, then replace `main-SNAPSHOT` using the template `PR<NR>-SNAPSHOT`. For
-example `PR40-SNAPSHOT`.
-
-If you want to depend on a single module, like `credentials`, then use the following dependencies
-
-```kotlin
-dependencies {
-  implementation("com.github.TBD54566975.web5-kt:credentials:master-SNAPSHOT")
-}
-```
+> Additional repositories, like `https://repo.danubetech.com/repository/maven-public/`, are required for resolving
+transitive dependencies.
 
 # Examples
 
@@ -111,16 +78,17 @@ and cannot be deleted.
 ### Manual Release
 
 If you want to do a manual release, you have two options:
-1. Dispatch the [publish workflow](./.github/workflows/publish.yml) workflow from the Github UI. Go to the [publish 
-   Actions](https://github.com/TBD54566975/web5-kt/actions) > "Run workflow". 
+
+1. Dispatch the [publish workflow](./.github/workflows/publish.yml) workflow from the Github UI. Go to the [publish
+   Actions](https://github.com/TBD54566975/web5-kt/actions) > "Run workflow".
 2. Setup your local environment to publish to Central Repository. This is more involved. You'll need to:
-   1. Define all the environment variables described in the [publish workflow](./.github/workflows/publish.yml) file. You
-      can find the values in the [secrets and variable](https://github.com/TBD54566975/web5-kt/settings/secrets/actions)
-      page.
-   2. Run the following command (you can change `samplebranch` to any branch name):
-      ```bash
-      ./gradlew -Pversion=samplebranch-SNAPSHOT publishToSonatype closeAndReleaseSonatypeStagingRepository
-      ```
+  1. Define all the environment variables described in the [publish workflow](./.github/workflows/publish.yml) file. You
+     can find the values in the [secrets and variable](https://github.com/TBD54566975/web5-kt/settings/secrets/actions)
+     page.
+  2. Run the following command (you can change `samplebranch` to any branch name):
+     ```bash
+     ./gradlew -Pversion=samplebranch-SNAPSHOT publishToSonatype closeAndReleaseSonatypeStagingRepository
+     ```
 
 # Other Docs
 


### PR DESCRIPTION
Now that we're confident that our publishing mechanism works (see #156), we can remove all references to jitpack.

This change is doc cleanup only.
