### PR TITLE
trigger sdk-development report build workflow when this repo is merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,26 @@ jobs:
                   https://analytics-api.buildkite.com/v1/uploads
             done
           done
+
+      - name: Generate an access token to trigger downstream repo
+        uses: actions/create-github-app-token@2986852ad836768dfea7781f31828eb3e17990fa # v1.6.2
+        id: generate_token
+        if: github.ref == 'refs/heads/main'
+        with:
+          app-id: ${{ secrets.CICD_ROBOT_GITHUB_APP_ID }}
+          private-key: ${{ secrets.CICD_ROBOT_GITHUB_APP_PRIVATE_KEY }}
+          owner: TBD54566975
+          repositories: sdk-development
+        
+      - name: Trigger sdk-development report build
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl -L \
+          -H "Authorization: Bearer ${APP_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -H "Content-Type: application/json" \
+          --fail \
+          --data '{"ref": "main"}' \
+          https://api.github.com/repos/TBD54566975/sdk-development/actions/workflows/build-report.yaml/dispatches
+        env:
+          APP_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
The [web5 spec compliance report](https://tbd54566975.github.io/sdk-development/) reports on the status of various features in this SDK. This PR makes sure we rebuild it whenever this repo changes, in case a new feature was added

