### PR TITLE
handroll Bencoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ repositories {
   mavenCentral()
   maven("https://jitpack.io")
   maven("https://repo.danubetech.com/repository/maven-public/")
-  maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
 
 dependencies {
@@ -82,13 +81,13 @@ If you want to do a manual release, you have two options:
 1. Dispatch the [publish workflow](./.github/workflows/publish.yml) workflow from the Github UI. Go to the [publish
    Actions](https://github.com/TBD54566975/web5-kt/actions) > "Run workflow".
 2. Setup your local environment to publish to Central Repository. This is more involved. You'll need to:
-  1. Define all the environment variables described in the [publish workflow](./.github/workflows/publish.yml) file. You
-     can find the values in the [secrets and variable](https://github.com/TBD54566975/web5-kt/settings/secrets/actions)
-     page.
-  2. Run the following command (you can change `samplebranch` to any branch name):
-     ```bash
-     ./gradlew -Pversion=samplebranch-SNAPSHOT publishToSonatype closeAndReleaseSonatypeStagingRepository
-     ```
+1. Define all the environment variables described in the [publish workflow](./.github/workflows/publish.yml) file. You
+   can find the values in the [secrets and variable](https://github.com/TBD54566975/web5-kt/settings/secrets/actions)
+   page.
+2. Run the following command (you can change `samplebranch` to any branch name):
+   ```bash
+   ./gradlew -Pversion=samplebranch-SNAPSHOT publishToSonatype closeAndReleaseSonatypeStagingRepository
+   ```
 
 # Other Docs
 

--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -8,7 +8,6 @@ repositories {
 
   maven("https://jitpack.io")
   maven("https://repo.danubetech.com/repository/maven-public/")
-  maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
 
 val ktor_version = "2.3.4"

--- a/dids/build.gradle.kts
+++ b/dids/build.gradle.kts
@@ -8,7 +8,6 @@ repositories {
   maven("https://repo.danubetech.com/repository/maven-public")
   maven("https://jitpack.io")
   maven("https://jcenter.bintray.com/")
-  maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
 
 val ktor_version = "2.3.4"

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/Bencoder.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/Bencoder.kt
@@ -1,0 +1,109 @@
+package web5.sdk.dids.methods.dht
+
+/**
+ * A singleton object for encoding and decoding data in Bencode format.
+ */
+public object Bencoder {
+
+  /**
+   * Encodes a given input into a Bencode formatted string.
+   *
+   * @param input The data to be encoded.
+   * @return The Bencode encoded string.
+   * @throws IllegalArgumentException If the input type is not supported.
+   */
+  public fun encode(input: Any): String = when (input) {
+    is String -> "${input.length}:$input"
+    is Int, Long -> "i${input}e"
+    is List<*> -> input.joinToString(separator = "", prefix = "l", postfix = "e") { encode(it!!) }
+    is Map<*, *> -> input.entries.joinToString(
+      separator = "",
+      prefix = "d",
+      postfix = "e"
+    ) { (key, value) -> encode(key!!) + encode(value!!) }
+
+    else -> throw IllegalArgumentException("Unsupported type: $input")
+  }
+
+  /**
+   * Encodes a given input into a Bencode formatted byte array. treats ByteArray
+   * input as a string
+   *
+   * @param input The data to be encoded.
+   * @return The Bencode encoded byte array.
+   * @throws IllegalArgumentException If the input type is not supported.
+   */
+  public fun encodeAsBytes(input: Any): ByteArray = when (input) {
+
+    is ByteArray -> {
+      "${input.size}:".toByteArray() + input
+    }
+
+    else -> encode(input).toByteArray()
+  }
+
+  /**
+   * Decodes a Bencode formatted string into its original data format.
+   *
+   * @param input The Bencode formatted string to be decoded.
+   * @return A Pair containing the decoded object and the length of the decoded string.
+   */
+  public fun decode(input: String): Pair<Any, Int> {
+    var index = 0
+    return when (val currChar = input[index]) {
+      'i', 'l', 'd' -> decodeType(input, currChar).also { index += it.second }
+      else -> decodeString(input).also { index += it.second }
+    }
+  }
+
+  // Helper function to delegate decoding based on the type character.
+  private fun decodeType(s: String, type: Char): Pair<Any, Int> = when (type) {
+    'i' -> decodeInt(s)
+    'l' -> decodeList(s)
+    'd' -> decodeDict(s)
+    else -> decodeString(s)
+  }
+
+  // Decodes a Bencode string.
+  private fun decodeString(s: String): Pair<String, Int> {
+    val lengthPart = s.split(":")[0]
+    val digitsInString = lengthPart.length
+    val length = lengthPart.toInt()
+    return Pair(
+      s.substring(digitsInString + 1, digitsInString + 1 + length),
+      digitsInString + 1 + length
+    )
+  }
+
+  // Decodes a Bencode integer.
+  private fun decodeInt(s: String): Pair<Int, Int> {
+    val eIndex = s.indexOf('e')
+    val i = s.substring(1, eIndex).toInt()
+    return Pair(i, eIndex + 1)
+  }
+
+  // Decodes a Bencode list.
+  private fun decodeList(s: String): Pair<List<Any>, Int> {
+    val xs = mutableListOf<Any>()
+    var index = 1
+    while (s[index] != 'e') {
+      val (b, i) = decode(s.substring(index))
+      xs.add(b)
+      index += i
+    }
+    return Pair(xs, index + 1)
+  }
+
+  // Decodes a Bencode dictionary.
+  private fun decodeDict(s: String): Pair<Map<Any, Any>, Int> {
+    val dict = mutableMapOf<Any, Any>()
+    var index = 1
+    while (s[index] != 'e') {
+      val (key, i1) = decode(s.substring(index))
+      val (value, i2) = decode(s.substring(index + i1))
+      dict[key] = value
+      index += i1 + i2
+    }
+    return Pair(dict, index + 1)
+  }
+}

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -19,7 +19,6 @@ import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.exceptions.PkarrRecordResponseException
-import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.SignatureException
@@ -187,7 +186,7 @@ internal class DhtClient(
       }
 
       // encode v using bencode
-      val vEncoded = bencode(v)
+      val vEncoded = Bencoder.encodeAsBytes(v)
 
       require(vEncoded.size <= 1000) {
         "Value must be <= 1000 bytes compressed, current bytes {${vEncoded.size}}"
@@ -207,16 +206,6 @@ internal class DhtClient(
       }
     }
 
-    /** Encodes a byte array according to https://en.wikipedia.org/wiki/Bencode. */
-    internal fun bencode(bs: ByteArray): ByteArray {
-      val out = ByteArrayOutputStream()
-      val l = bs.size.toString()
-      out.write(l.toByteArray(charset("UTF-8")))
-      out.write(colon)
-      out.write(bs)
-      return out.toByteArray()
-    }
-
     /**
      * Verifies a message according to the BEP44 Signature Verification specification.
      * https://www.bittorrent.org/beps/bep_0044.html
@@ -227,7 +216,8 @@ internal class DhtClient(
      * @throws SignatureException if the signature is invalid.
      */
     fun verifyBep44Message(message: Bep44Message) {
-      val vEncoded = bencode(message.v)
+      // encode v using bencode
+      val vEncoded = Bencoder.encodeAsBytes(message.v)
 
       // prepare buffer and verify
       val bytesToVerify = "3:seqi${message.seq}e1:v".toByteArray() + vEncoded

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/BencoderTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/BencoderTest.kt
@@ -1,0 +1,99 @@
+package web5.sdk.dids.methods.dht
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class BencoderTest {
+  @Nested
+  inner class Encode {
+    @Test
+    fun `should encode a list`() {
+      val encoded = Bencoder.encode(listOf("spam", "eggs"))
+      assertEquals(encoded, "l4:spam4:eggse")
+    }
+
+    @Test
+    fun `should encode a string`() {
+      val encoded = Bencoder.encode("")
+      assertEquals(encoded, "0:")
+    }
+
+    @Test
+    fun `should encode an empty list`() {
+      val encoded = Bencoder.encode(emptyList<Any>())
+      assertEquals(encoded, "le")
+    }
+
+    @Test
+    fun `should encode a dictionary`() {
+      val encoded = Bencoder.encode(mapOf("cow" to "moo", "spam" to "eggs"))
+      assertEquals(encoded, "d3:cow3:moo4:spam4:eggse")
+    }
+
+    @Test
+    fun `should encode empty dictionary`() {
+      val encoded = Bencoder.encode(emptyMap<Any, Any>())
+      assertEquals(encoded, "de")
+    }
+  }
+
+  @Nested
+  inner class EncodeAsBytes {
+    @Test
+    fun `encode an empty byte array`() {
+      val input = ByteArray(0)
+      val expected = "0:".toByteArray()
+      val result = Bencoder.encodeAsBytes(input)
+      assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun `encode a byte array with a single byte`() {
+      val input = byteArrayOf(65)
+      val expected = "1:A".toByteArray()
+      val result = Bencoder.encodeAsBytes(input)
+      assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun `encode a byte array with multiple bytes`() {
+      val input = byteArrayOf(65, 66, 67)
+      val expected = "3:ABC".toByteArray()
+      val result = Bencoder.encodeAsBytes(input)
+      assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun `encode a byte array with special characters`() {
+      val input = byteArrayOf(35, 36, 37)
+      val expected = "3:#$%".toByteArray()
+      val result = Bencoder.encodeAsBytes(input)
+      assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun `encode a very large byte array`() {
+      val input = ByteArray(1_000_000) { 65 }
+      val expected = "1000000:${"A".repeat(1_000_000)}".toByteArray()
+      val result = Bencoder.encodeAsBytes(input)
+      assertArrayEquals(expected, result)
+    }
+  }
+
+  @Nested
+  inner class Decode {
+    @Test
+    fun `should decode a dictionary string`() {
+      val encoded = "d9:publisher3:bob17:publisher-webpage15:www.example.com18:publisher.location4:homee"
+      val (result, _) = Bencoder.decode(encoded)
+      val expected = mapOf(
+        "publisher" to "bob",
+        "publisher-webpage" to "www.example.com",
+        "publisher.location" to "home"
+      )
+      assertEquals(result, expected)
+    }
+  }
+}

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
@@ -5,7 +5,6 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,55 +12,11 @@ import org.junit.jupiter.api.assertThrows
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Secp256k1
-import web5.sdk.dids.methods.dht.DhtClient.Companion.bencode
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DhtTest {
-  @Nested
-  inner class BencodeTest {
-    @Test
-    fun `encode an empty byte array`() {
-      val input = ByteArray(0)
-      val expected = "0:".toByteArray()
-      val result = bencode(input)
-      assertArrayEquals(expected, result)
-    }
-
-    @Test
-    fun `encode a byte array with a single byte`() {
-      val input = byteArrayOf(65)
-      val expected = "1:A".toByteArray()
-      val result = bencode(input)
-      assertArrayEquals(expected, result)
-    }
-
-    @Test
-    fun `encode a byte array with multiple bytes`() {
-      val input = byteArrayOf(65, 66, 67)
-      val expected = "3:ABC".toByteArray()
-      val result = bencode(input)
-      assertArrayEquals(expected, result)
-    }
-
-    @Test
-    fun `encode a byte array with special characters`() {
-      val input = byteArrayOf(35, 36, 37)
-      val expected = "3:#$%".toByteArray()
-      val result = bencode(input)
-      assertArrayEquals(expected, result)
-    }
-
-    @Test
-    fun `encode a very large byte array`() {
-      val input = ByteArray(1_000_000) { 65 }
-      val expected = "1000000:${"A".repeat(1_000_000)}".toByteArray()
-      val result = bencode(input)
-      assertArrayEquals(expected, result)
-    }
-  }
-
   @Nested
   inner class Bep44Test {
 


### PR DESCRIPTION
Had this branch sitting around locally for awhile and just remembered. Original intent was to handroll a Bencoder so we could drop the bittorrent dep we were pulling in because:
* it wasn't hosted on maven central (requiring downstream consumers to add yet another repository)
* it introduced a ton of CVEs

looks like @andresuribe87 beat me to it in his most recent PR to update `did:dht` to reflect the spec text changes we recently made

figured i'd toss this PR up anyway incase we want a more complete `Bencoder` (though not needed. @andresuribe87 implemented exactly what we needed in order to drop the dep)