### PR TITLE
Validate presentaion submission with new validator

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
@@ -146,8 +146,9 @@ public object PresentationExchange {
    * 1. Ensures that the presentation submission's id is not empty.
    * 2. Validates that the definitionId is not empty.
    * 3. Validates descriptorMap is a non-empty list.
-   * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.
-   * 5. Ensures that the path is valid across all levels of nesting
+   * 4. Check for unique inputDescriptor ids at top level
+   * 5. Verifies the input descriptor mapping ids are the same on all levels of nesting.
+   * 6. Ensures that the path is valid across all levels of nesting
    *
    * Throws an [PexValidationException] if the provided object does not conform to the Presentation Definition
    */

--- a/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
@@ -12,6 +12,7 @@ import web5.sdk.credentials.model.InputDescriptorV2
 import web5.sdk.credentials.model.PresentationDefinitionV2
 import web5.sdk.credentials.model.PresentationDefinitionV2Validator
 import web5.sdk.credentials.model.PresentationSubmission
+import web5.sdk.credentials.model.PresentationSubmissionValidator
 import java.util.UUID
 
 /**
@@ -134,6 +135,27 @@ public object PresentationExchange {
   @Throws(PexValidationException::class)
   public fun validateDefinition(presentationDefinition: PresentationDefinitionV2) {
     PresentationDefinitionV2Validator.validate(presentationDefinition)
+  }
+
+
+
+  /**
+   * Validates whether an object is usable as a presentation submission or not.
+   *
+   * Model as specified in https://identity.foundation/presentation-exchange/#presentation-submission.
+   *
+   * The checks are as follows:
+   * 1. Ensures that the presentation submission's ID is not empty.
+   * 2. Validates that the definitionId is not empty.
+   * 3. Validates descriptorMap is a non-empty list.
+   * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.
+   * 5. Ensures that the path is valid across all levels of nesting
+   *
+   * Throws an [PexValidationException] if the provided object does not conform to the Presentation Definition
+   */
+  @Throws(PexValidationException::class)
+  public fun validateSubmission(presentationSubmission: PresentationSubmission) {
+    PresentationSubmissionValidator.validate(presentationSubmission)
   }
 
   private fun mapInputDescriptorsToVCs(

--- a/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/PresentationExchange.kt
@@ -137,15 +137,13 @@ public object PresentationExchange {
     PresentationDefinitionV2Validator.validate(presentationDefinition)
   }
 
-
-
   /**
    * Validates whether an object is usable as a presentation submission or not.
    *
    * Model as specified in https://identity.foundation/presentation-exchange/#presentation-submission.
    *
    * The checks are as follows:
-   * 1. Ensures that the presentation submission's ID is not empty.
+   * 1. Ensures that the presentation submission's id is not empty.
    * 2. Validates that the definitionId is not empty.
    * 3. Validates descriptorMap is a non-empty list.
    * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.

--- a/credentials/src/main/kotlin/web5/sdk/credentials/model/Validator.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/model/Validator.kt
@@ -160,7 +160,7 @@ public object PresentationSubmissionValidator {
    * Validates a PresentationSubmission.
    *
    * This method performs several checks to ensure the integrity of the presentation submission model object:
-   * 1. Ensures that the presentation submission's ID is not empty.
+   * 1. Ensures that the presentation submission's id is not empty.
    * 2. Validates that the definitionId is not empty.
    * 3. Validates descriptorMap is a non-empty list.
    * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.

--- a/credentials/src/main/kotlin/web5/sdk/credentials/model/Validator.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/model/Validator.kt
@@ -163,8 +163,9 @@ public object PresentationSubmissionValidator {
    * 1. Ensures that the presentation submission's id is not empty.
    * 2. Validates that the definitionId is not empty.
    * 3. Validates descriptorMap is a non-empty list.
-   * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.
-   * 5. Ensures that the path is valid across all levels of nesting
+   * 4. Check for unique inputDescriptor ids at top level
+   * 5. Verifies the input descriptor mapping ids are the same on all levels of nesting.
+   * 6. Ensures that the path is valid across all levels of nesting
    * @throws PexValidationException if the PresentationDefinitionV2 is not valid.
    */
   public fun validate(presentationSubmission: PresentationSubmission) {
@@ -178,6 +179,12 @@ public object PresentationSubmissionValidator {
 
     if (presentationSubmission.descriptorMap.isEmpty()) {
       throw PexValidationException("PresentationSubmission descriptorMap should be a non-empty list")
+    }
+
+    // Check for unique inputDescriptor ids
+    val ids = presentationSubmission.descriptorMap.map { it.id }
+    if (ids.size != ids.toSet().size) {
+      throw PexValidationException("All descriptorMap top level ids must be unique")
     }
 
     validateDescriptorMap(presentationSubmission.descriptorMap)

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.credentials.model.PresentationDefinitionV2
+import web5.sdk.credentials.model.PresentationSubmission
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.methods.key.DidKey
 import web5.sdk.testing.TestVectors
@@ -618,6 +619,29 @@ class Web5TestVectorsPresentationExchange {
     testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
       assertFails {
           PresentationExchange.validateDefinition(vector.input.presentationDefinition)
+      }
+    }
+  }
+
+  data class ValidateSubmissionTestInput(
+    val presentationSubmission: PresentationSubmission,
+    val errors: Boolean
+  )
+  @Test
+  fun validate_submission() {
+    val typeRef = object : TypeReference<TestVectors<ValidateSubmissionTestInput, Unit>>() {}
+    val testVectors =
+      mapper.readValue(File("../web5-spec/test-vectors/presentation_exchange/validate_submission.json"), typeRef)
+
+    testVectors.vectors.filterNot { it.errors ?: false }.forEach { vector ->
+      assertDoesNotThrow {
+        PresentationExchange.validateSubmission(vector.input.presentationSubmission)
+      }
+    }
+
+    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+      assertFails {
+        PresentationExchange.validateSubmission(vector.input.presentationSubmission)
       }
     }
   }


### PR DESCRIPTION
This method performs several checks to ensure the integrity of the presentation submission model object:
   * 1. Ensures that the presentation submission's ID is not empty.
   * 2. Validates that the definitionId is not empty.
   * 3. Validates descriptorMap is a non-empty list.
   * 4. Verifies the input descriptor mapping ids are the same on all levels of nesting.
   * 5. Ensures that the path is valid across all levels of nesting
   
 Usage:
 ```
 try {
   PresentationExchange.validateSubmission(presentationSubmission)
 } catch(Exception e) {
   // invalid submission
 }
 ```


web5-spec vector change - https://github.com/TBD54566975/web5-spec/pull/109