### PR TITLE
Adding test vectors for Secp256k1

### DIFF
--- a/crypto/build.gradle.kts
+++ b/crypto/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
 
   testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.5")
   testImplementation(kotlin("test"))
+  testImplementation(project(":testing"))
 }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -247,6 +247,21 @@ public object Secp256k1 : KeyGenerator, Signer {
     return rBigint.toFixedByteArray(SIG_SIZE / 2) + sBigint.toFixedByteArray(SIG_SIZE / 2)
   }
 
+  /**
+   * Verifies a signature against a given payload using the ECDSA (Elliptic Curve Digital Signature Algorithm)
+   * with the curve `secp256k1`. This function supports deterministic k-value generation
+   * through HMAC and SHA-256, ensuring consistent verification outcomes for identical payloads
+   * and signatures.
+   *
+   * @param publicKey The public key used for verification, provided as a `JWK` (JSON Web Key).
+   * @param signedPayload The byte array containing the data that was signed.
+   * @param signature The byte array representing the signature to be verified against the payload.
+   * @param options Optional parameter to provide additional configuration for the verification process.
+   * @throws SignatureException If the signature does not validly correspond to the provided payload
+   *                            and public key, indicating either a data integrity issue
+   * @throws IllegalArgumentException If the provided public key or signature format is invalid or not
+   *                                  supported by the implementation.
+   */
   override fun verify(publicKey: JWK, signedPayload: ByteArray, signature: ByteArray, options: VerifyOptions?) {
     val publicKeyBytes = publicKeyToBytes(publicKey)
     val publicKeyPoint = spec.curve.decodePoint(publicKeyBytes)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
@@ -107,7 +107,7 @@ class Web5TestVectorsCryptoEs256k {
     val typeRef = object : TypeReference<TestVectors<SignTestInput, String>>() {}
     val testVectors = mapper.readValue(File("../web5-spec/test-vectors/crypto_es256k/sign.json"), typeRef)
 
-    testVectors.vectors.filter { it.errors != true }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
       val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
       val jwkMap = vector.input.key
       val ecJwk = ECKey.parse(jwkMap.toString())

--- a/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
@@ -135,7 +135,7 @@ class Web5TestVectorsCryptoEs256k {
     val typeRef = object : TypeReference<TestVectors<VerifyTestInput, Boolean>>() {}
     val testVectors = mapper.readValue(File("../web5-spec/test-vectors/crypto_es256k/verify.json"), typeRef)
 
-    testVectors.vectors.filter { it.errors != true }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
       val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
       val jwkMap = vector.input.key
       val signatureByteArray = hexStringToByteArray(vector.input.signature)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
@@ -1,13 +1,25 @@
 package web5.sdk.crypto
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.OctetKeyPair
+import com.nimbusds.jose.util.Base64URL
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
+import web5.sdk.testing.TestVectors
+import java.io.File
 import java.security.SignatureException
 import java.util.Random
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -78,5 +90,92 @@ class Secp256k1Test {
         throw e
       }
     }
+  }
+}
+
+class Web5TestVectorsCryptoEs256k {
+  data class SignTestInput(
+    val data: String,
+    val key: Map<String, Any>?,
+  )
+
+  data class VerifyTestInput(
+    val data: String,
+    val key: Map<String, Any>?,
+    val signature: String,
+  )
+
+  private val mapper = jacksonObjectMapper()
+
+  @Test
+  fun sign() {
+    val typeRef = object : TypeReference<TestVectors<SignTestInput, String>>() {}
+    val testVectors = mapper.readValue(File("../web5-spec/test-vectors/crypto_es256k/sign.json"), typeRef)
+
+    testVectors.vectors.filter { it.errors != true }.forEach { vector ->
+      val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
+      val jwkMap = vector.input.key
+      val ecJwk = ECKey.parse(jwkMap.toString())
+      val signedByteArray: ByteArray = Secp256k1.sign(ecJwk, inputByteArray)
+
+      val signedHex = byteArrayToHexString(signedByteArray)
+
+      assertEquals(vector.output, signedHex)
+    }
+
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
+      assertFails {
+        val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
+        val jwkMap = vector.input.key
+
+        val ecJwk = ECKey.parse(jwkMap.toString())
+
+        Secp256k1.sign(ecJwk, inputByteArray)
+      }
+    }
+  }
+
+  @Test
+  fun verify() {
+    val typeRef = object : TypeReference<TestVectors<VerifyTestInput, Boolean>>() {}
+    val testVectors = mapper.readValue(File("../web5-spec/test-vectors/crypto_es256k/verify.json"), typeRef)
+
+    testVectors.vectors.filter { it.errors != true }.forEach { vector ->
+      val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
+      val jwkMap = vector.input.key
+      val signatureByteArray = hexStringToByteArray(vector.input.signature)
+
+      val ecJwk = ECKey.parse(jwkMap.toString())
+
+      if (vector.output == true) {
+        assertDoesNotThrow { Secp256k1.verify(ecJwk, inputByteArray, signatureByteArray)  }
+      } else {
+        assertFails { Secp256k1.verify(ecJwk, inputByteArray, signatureByteArray)  }
+      }
+    }
+
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
+      assertFails {
+        val inputByteArray: ByteArray = hexStringToByteArray(vector.input.data)
+        val jwkMap = vector.input.key
+        val signatureByteArray = hexStringToByteArray(vector.input.signature)
+
+        val ecJwk = ECKey.parse(jwkMap.toString())
+        Secp256k1.verify(ecJwk, inputByteArray, signatureByteArray)
+      }
+    }
+  }
+
+  private fun hexStringToByteArray(s: String): ByteArray {
+    val len = s.length
+    val data = ByteArray(len / 2)
+    for (i in 0 until len step 2) {
+      data[i / 2] = ((Character.digit(s[i], 16) shl 4) + Character.digit(s[i + 1], 16)).toByte()
+    }
+    return data
+  }
+
+  private fun byteArrayToHexString(bytes: ByteArray): String {
+    return bytes.joinToString("") { "%02x".format(it) }
   }
 }

--- a/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
@@ -3,16 +3,11 @@ package web5.sdk.crypto
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
-import com.nimbusds.jose.jwk.OctetKeyPair
-import com.nimbusds.jose.util.Base64URL
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
 import web5.sdk.testing.TestVectors
 import java.io.File


### PR DESCRIPTION
# Overview
Adding test vectors for Secp256k1

# Description
Web5TestVectorsCryptoEs256k
sign()
verify()

Will get checkmarks for kt here:
https://tbd54566975.github.io/sdk-report-runner/