### PR TITLE
Fixes issue #176. Added VerifiableCredentialJwt to support verifyAndP…

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/StatusListCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/StatusListCredential.kt
@@ -229,7 +229,7 @@ public object StatusListCredential {
       val response: HttpResponse = this.get(url)
       if (response.status.isSuccess()) {
         val body = response.bodyAsText()
-        return VerifiableCredential.parseJwt(body)
+        return VerifiableCredentialJwt(body).verifyAndParse()
       } else {
         throw ClientRequestException(
           response,

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -65,7 +65,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
@@ -82,7 +82,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
@@ -99,7 +99,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
@@ -116,7 +116,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
@@ -135,7 +135,7 @@ class PresentationExchangeTest {
         data = DateOfBirth(dateOfBirth = "1/1/1111")
       )
 
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd) }
     }
 
@@ -152,7 +152,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "Data1")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "Address",
@@ -160,7 +160,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = Address("abc street 123")
       )
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt2, vcJwt1), pd) }
     }
@@ -178,7 +178,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirthSSN(dateOfBirth = "1999-01-01", ssn = "456-123-123")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt1), pd) }
     }
@@ -196,7 +196,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirthSSN(dateOfBirth = "1999-01-01", ssn = "456-123-123")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt1), pd) }
     }
@@ -215,7 +215,7 @@ class PresentationExchangeTest {
         data = DateOfBirth(dateOfBirth = "1/1/1111")
       )
 
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "Address",
@@ -224,7 +224,7 @@ class PresentationExchangeTest {
         data = Address(address = "123 abc street")
       )
 
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       assertDoesNotThrow { PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt2, vcJwt1), pd) }
     }
@@ -256,7 +256,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertThrows<IllegalArgumentException> {
         PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
@@ -281,7 +281,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertThrows<IllegalArgumentException> {
         PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
@@ -304,7 +304,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "01-02-03")
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertThrows<IllegalArgumentException> {
         PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
@@ -327,7 +327,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "01-02-03")
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertFailure {
         PresentationExchange.satisfiesPresentationDefinition(listOf(vcJwt), pd)
@@ -368,7 +368,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "Data1")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "Address",
@@ -376,7 +376,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = Address("abc street 123")
       )
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       val presentationSubmission = PresentationExchange.createPresentationFromCredentials(listOf(vcJwt2, vcJwt1), pd)
 
@@ -396,7 +396,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       assertFailure {
         PresentationExchange.createPresentationFromCredentials(listOf(vcJwt), pd)
@@ -416,7 +416,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "11/11/2011")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "DateOfBirth",
@@ -424,7 +424,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "12/12/2012")
       )
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       val presentationSubmission = PresentationExchange.createPresentationFromCredentials(listOf(vcJwt2, vcJwt1), pd)
 
@@ -448,7 +448,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt = vc.sign(issuerDid)
+      val vcJwt = vc.sign(issuerDid).verifiableCredentialJwt
 
       val selectedCreds = PresentationExchange.selectCredentials(listOf(vcJwt), pd)
 
@@ -469,7 +469,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "StreetCred",
@@ -477,7 +477,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       val selectedCreds = PresentationExchange.selectCredentials(listOf(vcJwt1, vcJwt2), pd)
 
@@ -498,7 +498,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = StreetCredibility(localRespect = "high", legit = true)
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "StreetCred",
@@ -507,7 +507,7 @@ class PresentationExchangeTest {
         data = StreetCredibility(localRespect = "high", legit = true)
       )
 
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       val vc3 = VerifiableCredential.create(
         type = "DateOfBirth",
@@ -516,7 +516,7 @@ class PresentationExchangeTest {
         data = DateOfBirth(dateOfBirth = "1-1-1111")
       )
 
-      val vcJwt3 = vc3.sign(issuerDid)
+      val vcJwt3 = vc3.sign(issuerDid).verifiableCredentialJwt
 
       val selectedCreds = PresentationExchange.selectCredentials(listOf(vcJwt1, vcJwt2, vcJwt3), pd)
 
@@ -537,7 +537,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirthSSN(dateOfBirth = "1999-01-01", ssn = "456-123-123")
       )
-      val vcJwt1 = vc1.sign(issuerDid)
+      val vcJwt1 = vc1.sign(issuerDid).verifiableCredentialJwt
 
       val vc2 = VerifiableCredential.create(
         type = "DateOfBirthSSN",
@@ -545,7 +545,7 @@ class PresentationExchangeTest {
         subject = holderDid.uri,
         data = DateOfBirth(dateOfBirth = "1999-01-01")
       )
-      val vcJwt2 = vc2.sign(issuerDid)
+      val vcJwt2 = vc2.sign(issuerDid).verifiableCredentialJwt
 
       val selectedCreds = PresentationExchange.selectCredentials(listOf(vcJwt1, vcJwt2), pd)
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/StatusListCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/StatusListCredentialTest.kt
@@ -409,7 +409,7 @@ class StatusListCredentialTest {
         addHandler { request ->
           when (request.url.fullPath) {
             "/credentials/status/3" -> {
-              val responseBody = slcJwt
+              val responseBody = slcJwt.verifiableCredentialJwt
               respond(responseBody, headers = headersOf("Content-Type", "application/json"))
             }
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -166,8 +166,13 @@ class VerifiableCredentialJwtTest {
     )
 
     val vcJwt = vc.sign(issuerDid)
+    val parsedVc = vcJwt.verifyAndParse()
 
-    assertNotNull(vcJwt.verifyAndParse())
+    assertNotNull(parsedVc)
+
+    assertEquals(vc.type, parsedVc.type)
+    assertEquals(vc.issuer, parsedVc.issuer)
+    assertEquals(vc.subject, parsedVc.subject)
   }
 
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -60,7 +60,7 @@ class VerifiableCredentialTest {
     val vcJwt = vc.sign(issuerDid)
 
     assertDoesNotThrow {
-      VerifiableCredential.verify(vcJwt)
+      VerifiableCredential.verify(vcJwt.verifiableCredentialJwt)
     }
   }
 
@@ -112,7 +112,7 @@ class VerifiableCredentialTest {
     )
 
     val vcJwt = vc.sign(issuerDid)
-    VerifiableCredential.verify(vcJwt)
+    VerifiableCredential.verify(vcJwt.verifiableCredentialJwt)
   }
 
   @Test
@@ -147,10 +147,34 @@ class VerifiableCredentialTest {
     )
   }
 
+
+}
+
+class VerifiableCredentialJwtTest {
+
+  @Test
+  fun `verifyAndParse verifies and parses valid jwt`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val vc = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true)
+    )
+
+    val vcJwt = vc.sign(issuerDid)
+
+    assertNotNull(vcJwt.verifyAndParse())
+  }
+
+
   @Test
   fun `parseJwt throws ParseException if argument is not a valid JWT`() {
     assertThrows(ParseException::class.java) {
-      VerifiableCredential.parseJwt("hi")
+      VerifiableCredentialJwt("hi").parseJwt()
     }
   }
 
@@ -171,7 +195,7 @@ class VerifiableCredentialTest {
     signedJWT.sign(signer)
     val randomJwt = signedJWT.serialize()
     val exception = assertThrows(IllegalArgumentException::class.java) {
-      VerifiableCredential.parseJwt(randomJwt)
+      VerifiableCredentialJwt(randomJwt).parseJwt()
     }
 
     assertEquals("jwt payload missing vc property", exception.message)
@@ -196,7 +220,7 @@ class VerifiableCredentialTest {
     val randomJwt = signedJWT.serialize()
 
     val exception = assertThrows(IllegalArgumentException::class.java) {
-      VerifiableCredential.parseJwt(randomJwt)
+      VerifiableCredentialJwt(randomJwt).parseJwt()
     }
 
     assertEquals("expected vc property in JWT payload to be an object", exception.message)
@@ -217,7 +241,7 @@ class VerifiableCredentialTest {
 
     val vcJwt = vc.sign(issuerDid)
 
-    val parsedVc = VerifiableCredential.parseJwt(vcJwt)
+    val parsedVc = vcJwt.parseJwt()
     assertNotNull(parsedVc)
 
     assertEquals(vc.type, parsedVc.type)
@@ -253,7 +277,7 @@ class Web5TestVectorsCredentials {
       val issuerDid = Did.load(vector.input.signerDidUri!!, keyManager)
       val vcJwt = vc.sign(issuerDid)
 
-      assertEquals(vector.output, vcJwt, vector.description)
+      assertEquals(vector.output, vcJwt.verifiableCredentialJwt, vector.description)
     }
 
     testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->


### PR DESCRIPTION
Refactored `VerifiableCredential`

# Overview
Refactored `VerifiableCredential` to prevent misuse of `parseJwt()` which could cause bad actors to submit unverified JWT tokens

# Description
Added `VerifiableCredentialJwt` and a `verifyAndParse()` function to handle the issues outlined in #176. Additionally, `sign()` now returns a `VerifiableCredentialJwt` instead of a `String` as the only public facing mechanism to enable `parseJwt()` (via `verifyAndPublish()`).

# How Has This Been Tested?
Existing tests have been refactored to align with these changes. New test class was created (`VerifiableCredentialJwtTest`) and new test was added to check that `verifyAndParse()` would work successfully when passed a valid token String. Negative scenarios still test the individual methods directly.

- [ ] verifyAndParse verifies and parses valid jwt - Validates that a token is parsed as expected
