### PR TITLE
Add support for developing on Replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,18 @@
+run = "./gradlew build --console=rich"
+
+hidden=["*.jar"]
+
+[nix]
+channel = "stable-23_11"
+
+[packager]
+language = "java"
+
+[packager.features]
+packageSearch = true
+
+[languages.kotlin]
+pattern = "**/*.{kt,kts,java}"
+
+[languages.kotlin.languageServer]
+start = ["kotlin-language-server"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/github/license/TBD54566975/web5-kt)](https://github.com/TBD54566975/web5-kt/blob/main/LICENSE)
 [![SDK Kotlin CI](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml/badge.svg)](https://github.com/TBD54566975/web5-kt/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/codecov/c/gh/tbd54566975/web5-kt/main?logo=codecov&logoColor=FFFFFF&style=flat-square&token=YI87CKF1LI)](https://codecov.io/github/TBD54566975/web5-kt)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/TBD54566975/web5-kt/badge)](https://securityscorecards.dev/viewer/?uri=github.com/TBD54566975/web5-kt)
+[![Run on Replit](https://replit.com/badge/github/TBD54566975/web5-kt)](https://replit.com/new/github/replit/TBD54566975/web5-kt)
 
 This repo contains 4 jvm packages:
 

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,9 @@
+{ pkgs }: {
+	deps = [
+		pkgs.jdk11
+		pkgs.kotlin
+		pkgs.gradle
+		pkgs.maven
+		pkgs.kotlin-language-server
+	];
+}


### PR DESCRIPTION
# Overview

Hey! I've been working on adding some config so these projects can be developed on Replit.

This adds some config to set up Kotlin, Java, Gradle, and LSP so you can develop and run tests for this repo on Replit. The Run button is wired up to run the test suite.

You can also try this out by forking my repl here: https://replit.com/@ConnorBrewster/web5-kt

# How Has This Been Tested?

Here is an example of one of the test suite runs:

![image](https://github.com/TBD54566975/web5-kt/assets/9086315/6f645519-e650-4616-ba24-53a24273a515)


# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [ ] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages

## References


