### PR TITLE
Bugfix/218

### DIFF
--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -16,16 +16,15 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.Did
+import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.extensions.load
-import web5.sdk.dids.methods.ion.CreateDidIonOptions
-import web5.sdk.dids.methods.ion.DidIon
-import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
+import web5.sdk.dids.methods.dht.CreateDidDhtOptions
+import web5.sdk.dids.methods.dht.DidDht
 import web5.sdk.dids.methods.key.DidKey
 import web5.sdk.testing.TestVectors
 import java.io.File
 import java.security.SignatureException
 import java.text.ParseException
-import java.util.UUID
 import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -47,7 +46,7 @@ class VerifiableCredentialTest {
         "2aWNlcyI6W119fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNsaVVIbHBQQjE0VVpkVzk4S250aG8zV2YxRjQxOU83cFhSMGhPeFAzRkNnIn0" +
         "sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlEU2FMNHZVNElzNmxDalp4YVp6Zl9lWFFMU3V5T3E5T0pNbVJHa2FFTzRCQSIsInJlY29" +
         "2ZXJ5Q29tbWl0bWVudCI6IkVpQzI0TFljVEdRN1JzaDdIRUl2TXQ0MGNGbmNhZGZReTdibDNoa3k0RkxUQ2cifX0"
-    val issuerDid = DidIon.load(didUri, keyManager)
+    val issuerDid = DidDht.load(didUri, keyManager)
     val holderDid = DidKey.create(keyManager)
 
     val vc = VerifiableCredential.create(
@@ -122,14 +121,16 @@ class VerifiableCredentialTest {
     //Create an ION DID without an assertionMethod
     val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
     val verificationJwk = keyManager.getPublicKey(alias)
-    val key = JsonWebKey2020VerificationMethod(
-      id = UUID.randomUUID().toString(),
-      publicKeyJwk = verificationJwk,
-      relationships = emptyList() //No assertionMethod
-    )
-    val issuerDid = DidIon.create(
+
+    val verificationMethodsToAdd = listOf(Triple(
+      verificationJwk,
+      // no assertionMethod
+      emptyArray<PublicKeyPurpose>(),
+      "did:web:tbd.website"
+    ))
+    val issuerDid = DidDht.create(
       InMemoryKeyManager(),
-      CreateDidIonOptions(verificationMethodsToAdd = listOf(key))
+      CreateDidDhtOptions(verificationMethods = verificationMethodsToAdd)
     )
 
     val header = JWSHeader.Builder(JWSAlgorithm.ES256K)

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
@@ -14,13 +14,12 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.credentials.model.InputDescriptorMapping
 import web5.sdk.credentials.model.PresentationSubmission
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.dids.methods.ion.CreateDidIonOptions
-import web5.sdk.dids.methods.ion.DidIon
-import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
+import web5.sdk.dids.PublicKeyPurpose
+import web5.sdk.dids.methods.dht.CreateDidDhtOptions
+import web5.sdk.dids.methods.dht.DidDht
 import web5.sdk.dids.methods.key.DidKey
 import java.security.SignatureException
 import java.text.ParseException
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -230,14 +229,14 @@ class VerifiablePresentationTest {
     //Create an ION DID without an assertionMethod
     val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
     val verificationJwk = keyManager.getPublicKey(alias)
-    val key = JsonWebKey2020VerificationMethod(
-      id = UUID.randomUUID().toString(),
-      publicKeyJwk = verificationJwk,
-      relationships = emptyList() //No assertionMethod
-    )
-    val issuerDid = DidIon.create(
+    val verificationMethodsToAdd = listOf(Triple(
+      verificationJwk,
+      emptyArray<PublicKeyPurpose>(),
+      "did:web:tbd.website"
+    ))
+    val issuerDid = DidDht.create(
       InMemoryKeyManager(),
-      CreateDidIonOptions(verificationMethodsToAdd = listOf(key))
+      CreateDidDhtOptions(verificationMethods = verificationMethodsToAdd)
     )
 
     val header = JWSHeader.Builder(JWSAlgorithm.ES256K)

--- a/dids/src/intTest/kotlin/web5/sdk/dids/DidIntegrationTest.kt
+++ b/dids/src/intTest/kotlin/web5/sdk/dids/DidIntegrationTest.kt
@@ -2,6 +2,7 @@ package web5.sdk.dids
 
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.methods.dht.DidDht
 import web5.sdk.dids.methods.ion.DidIon
 import web5.sdk.dids.methods.web.DidWeb
 import kotlin.test.assertContains
@@ -14,6 +15,12 @@ class DidIntegrationTest {
     val did = DidIon.create(InMemoryKeyManager())
     assertContains(did.uri, "did:ion:")
     assertTrue(did.creationMetadata!!.longFormDid.startsWith(did.uri))
+  }
+
+  @Test
+  fun `create dht did over network`() {
+    val did = DidDht.create(InMemoryKeyManager())
+    assertContains(did.uri, "did:dht:")
   }
 
   @Test

--- a/dids/src/main/kotlin/web5/sdk/dids/exceptions/ExceptionDeclarations.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/exceptions/ExceptionDeclarations.kt
@@ -40,3 +40,8 @@ public class InvalidIdentifierException(message: String, cause: Throwable) : Run
  * @param message the exception message detailing the error
  */
 public class DidResolutionException(message: String) : RuntimeException(message)
+
+/**
+ * Represents an HTTP response where the status code is outside the range considered success.
+ */
+public class InvalidStatusException(public val statusCode: Int, msg: String) : RuntimeException(msg)

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -37,6 +37,7 @@ import web5.sdk.dids.DidResolutionMetadata
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.ResolveDidOptions
+import web5.sdk.dids.exceptions.InvalidStatusException
 import web5.sdk.dids.methods.ion.models.AddPublicKeysAction
 import web5.sdk.dids.methods.ion.models.AddServicesAction
 import web5.sdk.dids.methods.ion.models.Commitment
@@ -752,10 +753,7 @@ public data class IonUpdateResult(
   public val keyAliases: KeyAliases
 )
 
-/**
- * Represents an HTTP response where the status code is outside the range considered success.
- */
-public class InvalidStatusException(public val statusCode: Int, msg: String) : RuntimeException(msg)
+
 
 /**
  * Represents an exception where the response from calling [DidIonApi.resolve] contains a non-empty value in

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/web/DidWeb.kt
@@ -28,7 +28,7 @@ import web5.sdk.dids.DidMethod
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.ResolutionError
 import web5.sdk.dids.ResolveDidOptions
-import web5.sdk.dids.methods.ion.InvalidStatusException
+import web5.sdk.dids.exceptions.InvalidStatusException
 import web5.sdk.dids.validateKeyMaterialInsideKeyManager
 import java.io.File
 import java.net.InetAddress

--- a/dids/src/test/kotlin/web5/sdk/dids/DidResolversTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/DidResolversTest.kt
@@ -3,7 +3,7 @@ package web5.sdk.dids
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.dids.methods.ion.DidIon
+import web5.sdk.dids.methods.dht.DidDht
 
 class DidResolversTest {
 
@@ -15,7 +15,7 @@ class DidResolversTest {
 
   @Test
   fun `resolving a default ion did contains assertion method`() {
-    val ionDid = DidIon.create(InMemoryKeyManager())
+    val ionDid = DidDht.create(InMemoryKeyManager())
 
     val resolutionResult = DidResolvers.resolve(ionDid.uri)
     assertNotNull(resolutionResult.didDocument!!.assertionMethodVerificationMethodsDereferenced)

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.whenever
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.PublicKeyPurpose
+import web5.sdk.dids.exceptions.InvalidStatusException
 import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service
 import web5.sdk.dids.methods.ion.models.SidetreeCreateOperation


### PR DESCRIPTION
# Overview
Remove DidIon from tests. Fixes #218 

# Description
Removed DidIon from all tests that are not directly related to testing DidIon. In most instances we replace DidIon with DidDht  (create and load). Left remaining tests which directly test DidIon which can safely be removed once DidIon is removed. 

# How Has This Been Tested?
Temporarily removed all code from DidIon.kt (and it's corresponding test) and fixed failing compiler and test issues. 

Refactored existing tests referencing DidIon and reran after replacing with DidDht. Added new integration test for DidDht, presuming that existing DidIon integration test will eventually be removed.

- [ ] `create dht did over network` create dht did and validates that the uri contains `did:dht`
