### PR TITLE
Version Alignment and Introducing Gradle Version Catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ If you want to build an artifact locally, you can do so by running the following
 ./gradlew publishToMavenLocal -PskipSigning=true -Pversion={your-local-version-name}
 ```
 
+## Dependency Management
+As Web5 is a platform intended to run in a single `ClassLoader`, 
+versions and dependencies must be aligned among the subprojects
+(sometimes called modules) of this project. To address, we declare
+versions in `gradle/libs.versions.toml` and import references defined
+there in the subproject `build.gradle.kts` files. More docs on this 
+approach using Gradle Version Catalogs is at the top of `gradle/libs.versions.toml`.
+
 ## Prerequisites
 
 Install java version 11. If you're installing a higher version, it must be compatible with Gradle 8.2.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URL
 
 plugins {
-  id("org.jetbrains.kotlin.jvm") version "1.9.+"
-  id("java-library")
+  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+  id("base")
   id("io.gitlab.arturbosch.detekt") version "1.23.+"
   `maven-publish`
   id("org.jetbrains.dokka") version "1.9.+"
@@ -15,6 +15,7 @@ plugins {
   signing
   idea
   id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+  id("version-catalog")
 }
 
 configurations.all {
@@ -150,7 +151,7 @@ subprojects {
       create<MavenPublication>(publicationName) {
         groupId = project.group.toString()
         artifactId = name
-        description = "Kotlin SDK for web5 functionality"
+        description = name
         version = project.property("version").toString()
         from(components["java"])
       }
@@ -158,7 +159,7 @@ subprojects {
         pom {
           name = publicationName
           packaging = "jar"
-          description.set("web5 kotlin SDK")
+          description.set("Web5 SDK for the JVM")
           url.set("https://github.com/TBD54566975/web5-kt")
           inceptionYear.set("2023")
           licenses {
@@ -240,14 +241,14 @@ publishing {
     create<MavenPublication>("web5") {
       groupId = project.group.toString()
       artifactId = name
-      description = "Kotlin SDK for web5 functionality"
+      description = "Web5 SDK for the JVM"
       version = project.property("version").toString()
       from(components["java"])
 
       pom {
-        packaging = "jar"
-        name = project.name
-        description.set("web5 kotlin SDK")
+        packaging = "pom"
+        name = "Web5 SDK for the JVM"
+        description.set("Web5 SDK for the JVM")
         url.set("https://github.com/TBD54566975/web5-kt")
         inceptionYear.set("2023")
         licenses {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,5 +8,25 @@ repositories {
 }
 
 dependencies {
+
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * versioning is centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+
+  // Project
+
+  // Implementation
+
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
 }

--- a/credentials/build.gradle.kts
+++ b/credentials/build.gradle.kts
@@ -11,31 +11,43 @@ repositories {
   maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
 
-val ktor_version = "2.3.4"
-val jackson_version = "2.14.2"
-
 dependencies {
-  api("com.danubetech:verifiable-credentials-java:1.6.0")
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * versioning is centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
 
+  // API
+  /*
+   * API Leak: https://github.com/TBD54566975/web5-kt/issues/228
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.comDanubetechVerifiableCredentials)
+
+  // Project
   implementation(project(":dids"))
   implementation(project(":common"))
   implementation(project(":crypto"))
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-  implementation("com.nfeld.jsonpathkt:jsonpathkt:2.0.1")
-  implementation("com.nimbusds:nimbus-jose-jwt:9.34")
-  implementation("decentralized-identity:did-common-java:1.9.0")
-  implementation("com.networknt:json-schema-validator:1.0.87")
 
-  implementation("io.ktor:ktor-client-core:$ktor_version")
-  implementation("io.ktor:ktor-client-okhttp:$ktor_version")
-  implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-  implementation("io.ktor:ktor-serialization-jackson:$ktor_version")
-  implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
-  implementation("io.ktor:ktor-client-logging:$ktor_version")
+  // Implementation
+  implementation(libs.comFasterXmlJacksonModuleKotlin)
+  implementation(libs.comNetworkntJsonSchemaValidator)
+  implementation(libs.comNfeldJsonpathkt)
+  implementation(libs.comNimbusdsJoseJwt)
+  implementation(libs.decentralizedIdentityDidCommonJava)
+  implementation(libs.bundles.ioKtorForCredentials)
 
-  testImplementation("io.ktor:ktor-client-mock:$ktor_version")
-
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
+  testImplementation(libs.ioKtorClientMock)
   testImplementation(kotlin("test"))
-  testImplementation("com.willowtreeapps.assertk:assertk:0.27.0")
+  testImplementation(libs.comWillowtreeappsAssertk)
   testImplementation(project(":testing"))
 }

--- a/crypto/build.gradle.kts
+++ b/crypto/build.gradle.kts
@@ -7,19 +7,43 @@ repositories {
   mavenCentral()
 }
 
-val bouncy_castle_version = "1.77"
-val jackson_version = "2.14.2"
-
 dependencies {
-  api("com.nimbusds:nimbus-jose-jwt:9.34")
-  implementation("com.google.crypto.tink:tink:1.10.0")
-  implementation("org.bouncycastle:bcprov-jdk15to18:$bouncy_castle_version")
-  implementation("org.bouncycastle:bcpkix-jdk15to18:$bouncy_castle_version")
+
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * versioning is centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+  /*
+   * API Leak: https://github.com/TBD54566975/web5-kt/issues/229
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.comNimbusdsJoseJwt)
+  /*
+   * API Leak: https://github.com/TBD54566975/web5-kt/issues/230
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.comAmazonawsAwsKms)
+
+  // Project
   implementation(project(":common"))
 
-  api("com.amazonaws:aws-java-sdk-kms:1.12.538")
+  // Implementation
+  implementation(libs.comGoogleCryptoTink)
+  implementation(libs.bundles.orgBouncycastle)
+  implementation(libs.comFasterXmlJacksonModuleKotlin)
 
-  testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
   testImplementation(project(":testing"))
 }

--- a/dids/build.gradle.kts
+++ b/dids/build.gradle.kts
@@ -11,33 +11,46 @@ repositories {
   maven("https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/")
 }
 
-val ktor_version = "2.3.4"
-val jackson_version = "2.14.2"
-
 dependencies {
-  api("decentralized-identity:did-common-java:1.9.0")
 
+  /**
+   * Maintainers - please do not declare versioning here at the module level;
+   * versioning is centralized for the platform in $projectRoot/gradle/libs.versions.toml
+   *
+   * Deps are declared in alphabetical order.
+   */
+
+  // API
+  /*
+   * API Leak: https://github.com/TBD54566975/web5-kt/issues/231
+   *
+   * Change and move to "implementation" when completed
+   */
+  api(libs.decentralizedIdentityDidCommonJava)
+
+  // Project
   implementation(project(":common"))
   implementation(project(":crypto"))
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version")
-  implementation("com.nimbusds:nimbus-jose-jwt:9.34")
-  implementation("com.github.multiformats:java-multibase:1.1.0")
-  implementation("io.github.oshai:kotlin-logging-jvm:6.0.2")
 
-  implementation("io.ktor:ktor-client-core:$ktor_version")
-  implementation("io.ktor:ktor-client-okhttp:$ktor_version")
-  implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
-  implementation("io.ktor:ktor-serialization-jackson:$ktor_version")
+  // Implementation
+  implementation(libs.comFasterXmlJacksonModuleKotlin)
+  implementation(libs.comNimbusdsJoseJwt)
+  implementation(libs.comGithubMultiformats)
+  implementation(libs.comSquareupOkhttp3)
+  implementation(libs.dnsJava)
+  implementation(libs.ioGithubErdtmanJavaJsonCanonicalization)
+  implementation(libs.ioGithubOshaiKotlinLogging)
+  implementation(libs.bundles.ioKtorForDids)
 
-  implementation("com.squareup.okhttp3:okhttp-dnsoverhttps:4.12.0")
-
-  implementation("io.github.erdtman:java-json-canonicalization:1.1")
-
+  // Test
+  /**
+   * Test dependencies may declare direct versions; they are not exported
+   * and therefore are within the remit of this module to self-define
+   * if desired.
+   */
   testImplementation(kotlin("test"))
-  testImplementation("io.ktor:ktor-client-mock:$ktor_version")
+  testImplementation(libs.ioKtorClientMock)
   testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
   testImplementation("commons-codec:commons-codec:1.16.0")
-
-  implementation("dnsjava:dnsjava:3.5.2")
   testImplementation(project(mapOf("path" to ":testing")))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,83 @@
+###
+# This section is where we declare the versioning and scope for dependencies of
+# the Web5 platform and projects building atop the Web5 platform.
+#
+# Submodules of Web5 should not define their own dependency versions
+# because these must all co-exist in the same ClassLoading environment, and
+# therefore have to be aligned across submodules. Thus we declare the versioning
+# requirements here at the platform level.
+#
+# If a submodule needs to introduce a new dependency or upgrade, define that
+# dependency and version here such that other submodules in the build may pick
+# up the same version. This will guarantee that submodule test suites are running
+# in the correct ClassLoading environment aligned with the Web5 platform.
+#
+# More about Gradle Version Catalogs:
+# https://docs.gradle.org/current/userguide/platforms.html
+#
+# Helpful Blog:
+# https://umang91.medium.com/version-catalogs-in-gradle-7-0-816873b59b47
+###
+
+[versions]
+com_amazonaws_aws_kms = "1.12.538"
+com_danubetech_verifiable-credentials = "1.6.0"
+com_fasterxml_jackson_module = "2.14.2"
+com_github_multiformats = "1.1.0"
+com_google_crypto_tink = "1.10.0"
+com_networknt_json_schema_validator = "1.0.87"
+com_nfeld_jsonpathkt = "2.0.1"
+com_nimbusds = "9.34"
+com_squareup_okhttp3 = "4.12.0"
+com_willowtreeapps_assertk = "0.27.0"
+decentralized_identity_did_common_java = "1.9.0"
+dnsjava = "3.5.2"
+io_github_erdtman_java_json_canonicalization = "1.1"
+io_github_oshai_kotlin_logging = "6.0.2"
+io_ktor = "2.3.7"
+org_bouncycastle = "1.77"
+
+[libraries]
+comAmazonawsAwsKms = { module = "com.amazonaws:aws-java-sdk-kms", version.ref = "com_amazonaws_aws_kms" }
+comDanubetechVerifiableCredentials = { module = "com.danubetech:verifiable-credentials-java", version.ref = "com_danubetech_verifiable-credentials" }
+comFasterXmlJacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "com_fasterxml_jackson_module" }
+comGithubMultiformats = { module = "com.github.multiformats:java-multibase", version.ref = "com_github_multiformats" }
+comGoogleCryptoTink = { module = "com.google.crypto.tink:tink", version.ref = "com_google_crypto_tink" }
+comNetworkntJsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "com_networknt_json_schema_validator" }
+comNfeldJsonpathkt = { module = "com.nfeld.jsonpathkt:jsonpathkt", version.ref = "com_nfeld_jsonpathkt" }
+comNimbusdsJoseJwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "com_nimbusds" }
+comSquareupOkhttp3 = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "com_squareup_okhttp3" }
+comWillowtreeappsAssertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "com_willowtreeapps_assertk" }
+decentralizedIdentityDidCommonJava= { module = "decentralized-identity:did-common-java", version.ref = "decentralized_identity_did_common_java" }
+dnsJava = { module = "dnsjava:dnsjava", version.ref = "dnsjava" }
+orgBouncycastleBcprov = { module = "org.bouncycastle:bcprov-jdk15to18", version.ref = "org_bouncycastle" }
+orgBouncycastleBcpkix = { module = "org.bouncycastle:bcpkix-jdk15to18", version.ref = "org_bouncycastle" }
+ioGithubErdtmanJavaJsonCanonicalization = { module = "io.github.erdtman:java-json-canonicalization", version.ref = "io_github_erdtman_java_json_canonicalization" }
+ioGithubOshaiKotlinLogging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "io_github_oshai_kotlin_logging" }
+ioKtorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "io_ktor" }
+ioKtorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "io_ktor" }
+ioKtorClientMock = { module = "io.ktor:ktor-client-mock", version.ref = "io_ktor" }
+ioKtorClientOkhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "io_ktor" }
+ioKtorContentClientNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "io_ktor" }
+ioKtorSerializationJackson = { module = "io.ktor:ktor-serialization-jackson", version.ref = "io_ktor" }
+ioKtorSerializationKotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "io_ktor" }
+
+[bundles]
+ioKtorForCredentials = [
+  "ioKtorClientCore",
+  "ioKtorClientLogging",
+  "ioKtorClientOkhttp",
+  "ioKtorContentClientNegotiation",
+  "ioKtorSerializationJackson",
+  "ioKtorSerializationKotlinxJson"
+] # ktor-client-mock not included here as it's typically used as a test dep, not an impl dep
+ioKtorForDids = [
+  "ioKtorClientCore",
+  "ioKtorClientOkhttp",
+  "ioKtorContentClientNegotiation",
+  "ioKtorSerializationJackson"
+]
+orgBouncycastle = [
+  "orgBouncycastleBcprov",
+  "orgBouncycastleBcpkix"
+]


### PR DESCRIPTION
Centralizes versions across the `web5-kt` submodules using Gradle Version Catalogs.

Kicking off draft PR now to get early authoritative CI feedback during development.

Addresses:
* #226 