### PR TITLE
Replace usage of nimbusds Algorithm and Curve with our own enums

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/util/JwtUtil.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/util/JwtUtil.kt
@@ -11,6 +11,7 @@ import com.nimbusds.jwt.SignedJWT
 import foundation.identity.did.DIDURL
 import web5.sdk.common.Convert
 import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.Jwa
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidResolvers
 import web5.sdk.dids.exceptions.DidResolutionException
@@ -31,8 +32,8 @@ public object JwtUtil {
    * the [did]. The result is a String in a JWT format.
    *
    * @param did The [Did] used to sign the credential.
-   * @param assertionMethodId An optional identifier for the assertion method that will be used for verification of the
-   *        produces signature.
+   * @param assertionMethodId An optional identifier for the assertion method
+   *        that will be used for verification of the produced signature.
    * @param jwtPayload the payload that is getting signed by the [Did]
    * @return The JWT representing the signed verifiable credential.
    *
@@ -146,6 +147,11 @@ public object JwtUtil {
     val toVerifyBytes = jwt.signingInput
     val signatureBytes = jwt.signature.decode()
 
-    Crypto.verify(publicKeyJwk, toVerifyBytes, signatureBytes, jwt.header.algorithm)
+    Crypto.verify(
+      publicKeyJwk,
+      toVerifyBytes,
+      signatureBytes,
+      Jwa.parse(jwt.header.algorithm?.name)
+    )
   }
 }

--- a/credentials/src/main/kotlin/web5/sdk/credentials/util/JwtUtil.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/util/JwtUtil.kt
@@ -150,8 +150,7 @@ public object JwtUtil {
     Crypto.verify(
       publicKeyJwk,
       toVerifyBytes,
-      signatureBytes,
-      Jwa.parse(jwt.header.algorithm?.name)
+      signatureBytes
     )
   }
 }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -13,9 +13,9 @@ import com.nimbusds.jwt.SignedJWT
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.Jwa
 import web5.sdk.dids.Did
 import web5.sdk.dids.extensions.load
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
@@ -121,7 +121,7 @@ class VerifiableCredentialTest {
     val keyManager = InMemoryKeyManager()
 
     //Create an ION DID without an assertionMethod
-    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = keyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val verificationJwk = keyManager.getPublicKey(alias)
     val key = JsonWebKey2020VerificationMethod(
       id = UUID.randomUUID().toString(),

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.Jwa
 import web5.sdk.dids.Did
 import web5.sdk.dids.extensions.load
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
@@ -120,7 +121,7 @@ class VerifiableCredentialTest {
     val keyManager = InMemoryKeyManager()
 
     //Create an ION DID without an assertionMethod
-    val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
     val verificationJwk = keyManager.getPublicKey(alias)
     val key = JsonWebKey2020VerificationMethod(
       id = UUID.randomUUID().toString(),

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.credentials.model.InputDescriptorMapping
 import web5.sdk.credentials.model.PresentationSubmission
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.Jwa
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
 import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
@@ -229,7 +229,7 @@ class VerifiablePresentationTest {
     val keyManager = InMemoryKeyManager()
 
     //Create an ION DID without an assertionMethod
-    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = keyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val verificationJwk = keyManager.getPublicKey(alias)
     val key = JsonWebKey2020VerificationMethod(
       id = UUID.randomUUID().toString(),

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiablePresentationTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.credentials.model.InputDescriptorMapping
 import web5.sdk.credentials.model.PresentationSubmission
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.Jwa
 import web5.sdk.dids.methods.ion.CreateDidIonOptions
 import web5.sdk.dids.methods.ion.DidIon
 import web5.sdk.dids.methods.ion.JsonWebKey2020VerificationMethod
@@ -228,7 +229,7 @@ class VerifiablePresentationTest {
     val keyManager = InMemoryKeyManager()
 
     //Create an ION DID without an assertionMethod
-    val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
     val verificationJwk = keyManager.getPublicKey(alias)
     val key = JsonWebKey2020VerificationMethod(
       id = UUID.randomUUID().toString(),

--- a/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
@@ -49,7 +49,7 @@ public class AwsKeyManager @JvmOverloads constructor(
   )
 
   private val algorithmDetails = mapOf(
-    Jwa.ES256K to AlgorithmDetails(
+    AlgorithmId.secp256k1 to AlgorithmDetails(
       algorithm = Jwa.ES256K,
       curve = JwaCurve.SECP256K1,
       keySpec = KeySpec.ECC_SECG_P256K1,
@@ -80,8 +80,9 @@ public class AwsKeyManager @JvmOverloads constructor(
 //    )
   )
 
-  private fun getAlgorithmDetails(algorithm: Jwa): AlgorithmDetails {
-    return algorithmDetails[algorithm] ?: throw IllegalArgumentException("Algorithm $algorithm is not supported")
+  private fun getAlgorithmDetails(algorithmId: AlgorithmId): AlgorithmDetails {
+    return algorithmDetails[algorithmId] ?:
+    throw IllegalArgumentException("Algorithm ${algorithmId.algorithmName} is not supported")
   }
 
   private fun getAlgorithmDetails(keySpec: KeySpec): AlgorithmDetails {
@@ -100,8 +101,8 @@ public class AwsKeyManager @JvmOverloads constructor(
    * @throws IllegalArgumentException if the [algorithm] is not supported by AWS
    * @throws [AWSKMSException] for any error originating from the [AWSKMS] client
    */
-  override fun generatePrivateKey(algorithm: Jwa, curve: JwaCurve?, options: KeyGenOptions?): String {
-    val keySpec = getAlgorithmDetails(algorithm).keySpec
+  override fun generatePrivateKey(algorithmId: AlgorithmId, options: KeyGenOptions?): String {
+    val keySpec = getAlgorithmDetails(algorithmId).keySpec
     val createKeyRequest = CreateKeyRequest()
       .withKeySpec(keySpec)
       .withKeyUsage(KeyUsageType.SIGN_VERIFY)

--- a/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
@@ -51,7 +51,7 @@ public class AwsKeyManager @JvmOverloads constructor(
   private val algorithmDetails = mapOf(
     AlgorithmId.secp256k1 to AlgorithmDetails(
       algorithm = Jwa.ES256K,
-      curve = JwaCurve.SECP256K1,
+      curve = JwaCurve.secp256k1,
       keySpec = KeySpec.ECC_SECG_P256K1,
       signingAlgorithm = SigningAlgorithmSpec.ECDSA_SHA_256,
       newDigest = { SHA256Digest() }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
@@ -12,10 +12,8 @@ import com.amazonaws.services.kms.model.KeyUsageType
 import com.amazonaws.services.kms.model.MessageType
 import com.amazonaws.services.kms.model.SignRequest
 import com.amazonaws.services.kms.model.SigningAlgorithmSpec
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.impl.ECDSA
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
@@ -43,17 +41,17 @@ public class AwsKeyManager @JvmOverloads constructor(
 ) : KeyManager {
 
   private data class AlgorithmDetails(
-    val algorithm: JWSAlgorithm,
-    val curve: Curve,
+    val algorithm: Jwa,
+    val curve: JwaCurve,
     val keySpec: KeySpec,
     val signingAlgorithm: SigningAlgorithmSpec,
     val newDigest: () -> ExtendedDigest
   )
 
   private val algorithmDetails = mapOf(
-    JWSAlgorithm.ES256K to AlgorithmDetails(
-      algorithm = JWSAlgorithm.ES256K,
-      curve = Curve.SECP256K1,
+    Jwa.ES256K to AlgorithmDetails(
+      algorithm = Jwa.ES256K,
+      curve = JwaCurve.SECP256K1,
       keySpec = KeySpec.ECC_SECG_P256K1,
       signingAlgorithm = SigningAlgorithmSpec.ECDSA_SHA_256,
       newDigest = { SHA256Digest() }
@@ -82,7 +80,7 @@ public class AwsKeyManager @JvmOverloads constructor(
 //    )
   )
 
-  private fun getAlgorithmDetails(algorithm: Algorithm): AlgorithmDetails {
+  private fun getAlgorithmDetails(algorithm: Jwa): AlgorithmDetails {
     return algorithmDetails[algorithm] ?: throw IllegalArgumentException("Algorithm $algorithm is not supported")
   }
 
@@ -102,7 +100,7 @@ public class AwsKeyManager @JvmOverloads constructor(
    * @throws IllegalArgumentException if the [algorithm] is not supported by AWS
    * @throws [AWSKMSException] for any error originating from the [AWSKMS] client
    */
-  override fun generatePrivateKey(algorithm: Algorithm, curve: Curve?, options: KeyGenOptions?): String {
+  override fun generatePrivateKey(algorithm: Jwa, curve: JwaCurve?, options: KeyGenOptions?): String {
     val keySpec = getAlgorithmDetails(algorithm).keySpec
     val createKeyRequest = CreateKeyRequest()
       .withKeySpec(keySpec)
@@ -130,11 +128,11 @@ public class AwsKeyManager @JvmOverloads constructor(
 
     val algorithmDetails = getAlgorithmDetails(publicKeyResponse.keySpec.enum())
     val jwkBuilder = when (publicKey) {
-      is ECPublicKey -> ECKey.Builder(algorithmDetails.curve, publicKey)
+      is ECPublicKey -> ECKey.Builder(JwaCurve.toJwkCurve(algorithmDetails.curve), publicKey)
       else -> throw IllegalArgumentException("Unknown key type $publicKey")
     }
     return jwkBuilder
-      .algorithm(algorithmDetails.algorithm)
+      .algorithm(Jwa.toJwsAlgorithm(algorithmDetails.algorithm))
       .keyID(keyAlias)
       .keyUse(KeyUse.SIGNATURE)
       .build()
@@ -161,7 +159,7 @@ public class AwsKeyManager @JvmOverloads constructor(
       .withSigningAlgorithm(algorithmDetails.signingAlgorithm)
     val signResponse = kmsClient.sign(signRequest)
     val derSignatureBytes = signResponse.signature.array()
-    return transcodeDerSignatureToConcat(derSignatureBytes, algorithmDetails.algorithm)
+    return transcodeDerSignatureToConcat(derSignatureBytes, Jwa.toJwsAlgorithm(algorithmDetails.algorithm))
   }
 
   /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/AwsKeyManager.kt
@@ -81,8 +81,8 @@ public class AwsKeyManager @JvmOverloads constructor(
   )
 
   private fun getAlgorithmDetails(algorithmId: AlgorithmId): AlgorithmDetails {
-    return algorithmDetails[algorithmId] ?:
-    throw IllegalArgumentException("Algorithm ${algorithmId.algorithmName} is not supported")
+    return algorithmDetails[algorithmId]
+      ?: throw IllegalArgumentException("Algorithm ${algorithmId.algorithmName} is not supported")
   }
 
   private fun getAlgorithmDetails(keySpec: KeySpec): AlgorithmDetails {
@@ -94,11 +94,10 @@ public class AwsKeyManager @JvmOverloads constructor(
    * Generates and securely stores a private key based on the provided algorithm and options,
    * returning a unique alias that can be utilized to reference the generated key for future operations.
    *
-   * @param algorithm The cryptographic algorithm to use for key generation.
-   * @param curve (Optional) The elliptic curve to use (relevant for EC algorithms).
+   * @param algorithmId The algorithmId to use for key generation.
    * @param options (Optional) Additional options to control key generation behavior.
    * @return A unique alias (String) that can be used to reference the stored key.
-   * @throws IllegalArgumentException if the [algorithm] is not supported by AWS
+   * @throws IllegalArgumentException if the [algorithmId] is not supported by AWS
    * @throws [AWSKMSException] for any error originating from the [AWSKMS] client
    */
   override fun generatePrivateKey(algorithmId: AlgorithmId, options: KeyGenOptions?): String {

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -106,20 +106,15 @@ public enum class AlgorithmId(public val curveName: String, public val algorithm
      * Converts JwaCurve and Jwa combination into a valid AlgorithmId.
      *
      * @param curve JwaCurve
-     * @param algorithm Jwa
      * @return AlgorithmId that matches the provided curve and algorithm combination
      * @throws IllegalArgumentException if the combination of curve and algorithm is not supported
      */
-    @JvmOverloads
-    public fun from(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
-      return when (algorithm to curve) {
-        // todo do i need to add the null algo or null curve cases?
-        Jwa.ES256K to JwaCurve.secp256k1 -> secp256k1
-        Jwa.EdDSA to JwaCurve.Ed25519 -> Ed25519
-        null to JwaCurve.Ed25519 -> Ed25519
+    public fun from(curve: JwaCurve?): AlgorithmId {
+      return when (curve) {
+        JwaCurve.secp256k1 -> secp256k1
+        JwaCurve.Ed25519 -> Ed25519
         else -> throw IllegalArgumentException(
-          "Unknown combination of algorithm to curve: " +
-            "${algorithm?.name} to ${curve?.name}"
+          "Unknown curve to match to a known algorithmId: ${curve?.name}"
         )
       }
     }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -1,0 +1,123 @@
+package web5.sdk.crypto
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.Curve
+
+/**
+ * JSON Web Algorithm Curve.
+ *
+ * @property curveName
+ * @property identifier
+ * @property oid
+ */
+public enum class JwaCurve(public val curveName: String, public val identifier: String, public val oid: String?) {
+  SECP256K1("secp256k1", "secp256k1", "1.3.132.0.10"),
+  Ed25519("Ed25519", "Ed25519", null);
+
+  public companion object {
+    /**
+     * Parse name of a curve into JwaCurve.
+     *
+     * @param curveName
+     * @return JwaCurve
+     */
+    public fun parse(curveName: String?): JwaCurve? {
+      return if (!curveName.isNullOrEmpty()) {
+        when (curveName) {
+          SECP256K1.curveName -> SECP256K1
+          Ed25519.curveName -> Ed25519
+          else -> throw IllegalArgumentException("Unknown curve: $curveName")
+        }
+      } else {
+        null
+      }
+    }
+
+    /**
+     * Convert JwaCurve nimbusds JWK curve.
+     *
+     * @param curve
+     * @return nimbus JWK Curve
+     */
+    public fun toJwkCurve(curve: JwaCurve): Curve {
+      return when (curve) {
+        SECP256K1 -> Curve.SECP256K1
+        Ed25519 -> Curve.Ed25519
+      }
+    }
+  }
+}
+
+/**
+ * JSON Web Algorithm enum class.
+ */
+public enum class Jwa {
+  EdDSA,
+  ES256K;
+
+  public companion object {
+    /**
+     * Parse algorithm name into Jwa.
+     *
+     * @param algorithmName
+     * @return Jwa
+     */
+    public fun parse(algorithmName: String?): Jwa? {
+      return if (!algorithmName.isNullOrEmpty()) {
+        when (algorithmName) {
+          EdDSA.name -> EdDSA
+          ES256K.name -> ES256K
+          else -> throw IllegalArgumentException("Unknown algorithm: $algorithmName")
+        }
+      } else {
+        null
+      }
+    }
+
+    /**
+     * Convert Jwa to nimbusds JWSAlgorithm.
+     *
+     * @param algorithm
+     * @return JWSAlgorithm
+     */
+    public fun toJwsAlgorithm(algorithm: Jwa): JWSAlgorithm {
+      return when (algorithm) {
+        EdDSA -> JWSAlgorithm.EdDSA
+        ES256K -> JWSAlgorithm.ES256K
+      }
+    }
+  }
+}
+
+/**
+ * Algorithm id.
+ *
+ * @property curveName
+ * @property algorithmName
+ * @constructor Create empty Algorithm id
+ */
+public enum class AlgorithmId(public val curveName: String, public val algorithmName: String? = null) {
+  secp256k1("secp256k1", "ES256K"),
+  Ed25519("Ed25519");
+
+  public companion object {
+    /**
+     * Parse.
+     *
+     * @param curve
+     * @param algorithm
+     * @return
+     */
+    @JvmOverloads
+    public fun parse(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
+      return when (algorithm to curve) {
+        Jwa.ES256K to JwaCurve.SECP256K1 -> secp256k1
+        Jwa.EdDSA to JwaCurve.Ed25519 -> Ed25519
+        null to JwaCurve.Ed25519 -> Ed25519
+        else -> throw IllegalArgumentException(
+          "Unknown combination of algorithm to curve: " +
+            "${algorithm?.name} to ${curve?.name}")
+      }
+    }
+  }
+}

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -6,15 +6,10 @@ import com.nimbusds.jose.jwk.Curve
 /**
  * JSON Web Algorithm Curve.
  *
- * @property curveName name of the curve.
  */
-public enum class JwaCurve(public val curveName: String) {
-  // todo nimbusds had identifier and oid but i don't think i need it
-//  SECP256K1("secp256k1", "secp256k1", "1.3.132.0.10"),
-//  Ed25519("Ed25519", "Ed25519", null);
-
-  SECP256K1("secp256k1"),
-  Ed25519("Ed25519");
+public enum class JwaCurve {
+  secp256k1,
+  Ed25519;
 
   public companion object {
     /**
@@ -27,8 +22,8 @@ public enum class JwaCurve(public val curveName: String) {
     public fun parse(curveName: String?): JwaCurve? {
       return if (!curveName.isNullOrEmpty()) {
         when (curveName) {
-          SECP256K1.curveName -> SECP256K1
-          Ed25519.curveName -> Ed25519
+          secp256k1.name -> secp256k1
+          Ed25519.name -> Ed25519
           else -> throw IllegalArgumentException("Unknown curve: $curveName")
         }
       } else {
@@ -45,7 +40,7 @@ public enum class JwaCurve(public val curveName: String) {
      */
     public fun toJwkCurve(curve: JwaCurve): Curve {
       return when (curve) {
-        SECP256K1 -> Curve.SECP256K1
+        secp256k1 -> Curve.SECP256K1
         Ed25519 -> Curve.Ed25519
       }
     }
@@ -103,8 +98,8 @@ public enum class Jwa {
  * @property algorithmName name of the algorithm
  */
 public enum class AlgorithmId(public val curveName: String, public val algorithmName: String? = null) {
-  secp256k1(JwaCurve.SECP256K1.curveName, Jwa.ES256K.name),
-  Ed25519(JwaCurve.Ed25519.curveName);
+  secp256k1(JwaCurve.secp256k1.name, Jwa.ES256K.name),
+  Ed25519(JwaCurve.Ed25519.name);
 
   public companion object {
     /**
@@ -119,7 +114,7 @@ public enum class AlgorithmId(public val curveName: String, public val algorithm
     public fun from(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
       return when (algorithm to curve) {
         // todo do i need to add the null algo or null curve cases?
-        Jwa.ES256K to JwaCurve.SECP256K1 -> secp256k1
+        Jwa.ES256K to JwaCurve.secp256k1 -> secp256k1
         Jwa.EdDSA to JwaCurve.Ed25519 -> Ed25519
         null to JwaCurve.Ed25519 -> Ed25519
         else -> throw IllegalArgumentException(

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -6,20 +6,23 @@ import com.nimbusds.jose.jwk.Curve
 /**
  * JSON Web Algorithm Curve.
  *
- * @property curveName
- * @property identifier
- * @property oid
+ * @property curveName name of the curve.
  */
-public enum class JwaCurve(public val curveName: String, public val identifier: String, public val oid: String?) {
-  SECP256K1("secp256k1", "secp256k1", "1.3.132.0.10"),
-  Ed25519("Ed25519", "Ed25519", null);
+public enum class JwaCurve(public val curveName: String) {
+  // todo nimbusds had identifier and oid but i don't think i need it
+//  SECP256K1("secp256k1", "secp256k1", "1.3.132.0.10"),
+//  Ed25519("Ed25519", "Ed25519", null);
+
+  SECP256K1("secp256k1"),
+  Ed25519("Ed25519");
 
   public companion object {
     /**
      * Parse name of a curve into JwaCurve.
      *
-     * @param curveName
-     * @return JwaCurve
+     * @param curveName name of the curve
+     * @return JwaCurve which corresponds to the curveName
+     * @throws IllegalArgumentException if the curveName is not supported
      */
     public fun parse(curveName: String?): JwaCurve? {
       return if (!curveName.isNullOrEmpty()) {
@@ -35,7 +38,8 @@ public enum class JwaCurve(public val curveName: String, public val identifier: 
 
     /**
      * Convert JwaCurve nimbusds JWK curve.
-     *
+     * Used to temporarily bridge the gap between moving from nimbusds JWK methods
+     * to rolling our own JWK methods
      * @param curve
      * @return nimbus JWK Curve
      */
@@ -49,7 +53,7 @@ public enum class JwaCurve(public val curveName: String, public val identifier: 
 }
 
 /**
- * JSON Web Algorithm enum class.
+ * JSON Web Algorithm Curve.
  */
 public enum class Jwa {
   EdDSA,
@@ -59,8 +63,9 @@ public enum class Jwa {
     /**
      * Parse algorithm name into Jwa.
      *
-     * @param algorithmName
-     * @return Jwa
+     * @param algorithmName name of the algorithm
+     * @return Jwa Json Web Algorithm
+     * @throws IllegalArgumentException if the algorithmName is not supported
      */
     public fun parse(algorithmName: String?): Jwa? {
       return if (!algorithmName.isNullOrEmpty()) {
@@ -76,9 +81,11 @@ public enum class Jwa {
 
     /**
      * Convert Jwa to nimbusds JWSAlgorithm.
+     * Used to temporarily bridge the gap between moving from nimbusds JWK methods
+     * to rolling our own JWK methods
      *
-     * @param algorithm
-     * @return JWSAlgorithm
+     * @param algorithm Jwa
+     * @return JWSAlgorithm nimbusds JWSAlgorithm
      */
     public fun toJwsAlgorithm(algorithm: Jwa): JWSAlgorithm {
       return when (algorithm) {
@@ -90,11 +97,10 @@ public enum class Jwa {
 }
 
 /**
- * Algorithm id.
+ * AlgorithmId - combination of valid curve and algorithm.
  *
- * @property curveName
- * @property algorithmName
- * @constructor Create empty Algorithm id
+ * @property curveName name of the curve
+ * @property algorithmName name of the algorithm
  */
 public enum class AlgorithmId(public val curveName: String, public val algorithmName: String? = null) {
   secp256k1("secp256k1", "ES256K"),
@@ -102,14 +108,15 @@ public enum class AlgorithmId(public val curveName: String, public val algorithm
 
   public companion object {
     /**
-     * Parse.
+     * Converts JwaCurve and Jwa combination into a valid AlgorithmId.
      *
-     * @param curve
-     * @param algorithm
-     * @return
+     * @param curve JwaCurve
+     * @param algorithm Jwa
+     * @return AlgorithmId that matches the provided curve and algorithm combination
+     * @throws IllegalArgumentException if the combination of curve and algorithm is not supported
      */
     @JvmOverloads
-    public fun parse(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
+    public fun from(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
       return when (algorithm to curve) {
         // todo do i need to add the null algo or null curve cases?
         Jwa.ES256K to JwaCurve.SECP256K1 -> secp256k1
@@ -117,7 +124,8 @@ public enum class AlgorithmId(public val curveName: String, public val algorithm
         null to JwaCurve.Ed25519 -> Ed25519
         else -> throw IllegalArgumentException(
           "Unknown combination of algorithm to curve: " +
-            "${algorithm?.name} to ${curve?.name}")
+            "${algorithm?.name} to ${curve?.name}"
+        )
       }
     }
   }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -111,6 +111,7 @@ public enum class AlgorithmId(public val curveName: String, public val algorithm
     @JvmOverloads
     public fun parse(curve: JwaCurve?, algorithm: Jwa? = null): AlgorithmId {
       return when (algorithm to curve) {
+        // todo do i need to add the null algo or null curve cases?
         Jwa.ES256K to JwaCurve.SECP256K1 -> secp256k1
         Jwa.EdDSA to JwaCurve.Ed25519 -> Ed25519
         null to JwaCurve.Ed25519 -> Ed25519

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Dsa.kt
@@ -103,8 +103,8 @@ public enum class Jwa {
  * @property algorithmName name of the algorithm
  */
 public enum class AlgorithmId(public val curveName: String, public val algorithmName: String? = null) {
-  secp256k1("secp256k1", "ES256K"),
-  Ed25519("Ed25519");
+  secp256k1(JwaCurve.SECP256K1.curveName, Jwa.ES256K.name),
+  Ed25519(JwaCurve.Ed25519.curveName);
 
   public companion object {
     /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -32,6 +32,9 @@ import java.security.SignatureException
 
 public object Ed25519 : KeyGenerator, Signer {
   override val algorithm: Jwa = Jwa.EdDSA
+  override val curve: JwaCurve = JwaCurve.Ed25519
+  override val keyType: String = "OKP"
+
 
   public const val PUB_MULTICODEC: Int = 0xed
   public const val PRIV_MULTICODEC: Int = 0x1300
@@ -139,6 +142,7 @@ public object Ed25519 : KeyGenerator, Signer {
     require(!key.isPrivate) { "key must be public" }
     validateKey(key)
   }
+
   /**
    * Validates the provided [JWK] (JSON Web Key) to ensure it conforms to the expected key type and format.
    *
@@ -156,6 +160,7 @@ public object Ed25519 : KeyGenerator, Signer {
     require(key.isPrivate) { "key must be private" }
     validateKey(key)
   }
+
   /**
    * Validates the provided [JWK] (JSON Web Key) to ensure it conforms to the expected key type and format.
    *

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -4,7 +4,6 @@ import com.google.crypto.tink.subtle.Ed25519Sign
 import com.google.crypto.tink.subtle.Ed25519Verify
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWK
-import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.OctetKeyPair
 import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator
@@ -14,7 +13,6 @@ import web5.sdk.common.Convert
 import web5.sdk.crypto.Ed25519.PRIV_MULTICODEC
 import web5.sdk.crypto.Ed25519.PUB_MULTICODEC
 import web5.sdk.crypto.Ed25519.algorithm
-import web5.sdk.crypto.Ed25519.keyType
 import java.security.GeneralSecurityException
 import java.security.SignatureException
 
@@ -28,14 +26,12 @@ import java.security.SignatureException
  * TODO: Insert example usage here.
  *
  * @property algorithm Specifies the JWS algorithm type. For Ed25519, this is `EdDSA`.
- * @property keyType Specifies the key type. For Ed25519, this is `OKP`.
  * @property PUB_MULTICODEC A byte array representing the multicodec prefix for an Ed25519 public key.
  * @property PRIV_MULTICODEC A byte array representing the multicodec prefix for an Ed25519 private key.
  */
 
 public object Ed25519 : KeyGenerator, Signer {
   override val algorithm: Jwa = Jwa.EdDSA
-  override val keyType: KeyType = KeyType.OKP
 
   public const val PUB_MULTICODEC: Int = 0xed
   public const val PRIV_MULTICODEC: Int = 0x1300
@@ -47,7 +43,7 @@ public object Ed25519 : KeyGenerator, Signer {
    * @return The generated private key in JWK format.
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
-    return OctetKeyPairGenerator(JwaCurve.toJwkCurve(JwaCurve.Ed25519))
+    return OctetKeyPairGenerator(com.nimbusds.jose.jwk.Curve.Ed25519)
       .algorithm(JWSAlgorithm.EdDSA)
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
@@ -86,7 +82,7 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPrivateKey = Convert(privateKeyBytes).toBase64Url(padding = false)
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
-    return OctetKeyPair.Builder(JwaCurve.toJwkCurve(JwaCurve.Ed25519), Base64URL(base64UrlEncodedPublicKey))
+    return OctetKeyPair.Builder(com.nimbusds.jose.jwk.Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
       .algorithm(Jwa.toJwsAlgorithm(algorithm))
       .keyIDFromThumbprint()
       .d(Base64URL(base64UrlEncodedPrivateKey))
@@ -97,7 +93,7 @@ public object Ed25519 : KeyGenerator, Signer {
   override fun bytesToPublicKey(publicKeyBytes: ByteArray): JWK {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
-    return OctetKeyPair.Builder(JwaCurve.toJwkCurve(JwaCurve.Ed25519), Base64URL(base64UrlEncodedPublicKey))
+    return OctetKeyPair.Builder(com.nimbusds.jose.jwk.Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
       .algorithm(Jwa.toJwsAlgorithm(algorithm))
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
@@ -165,7 +161,6 @@ public object Ed25519 : KeyGenerator, Signer {
    *
    * This function checks the following:
    * - The key must be an instance of [OctetKeyPair].
-   * - The key type (`kty`) must be [KeyType.OKP] (Octet Key Pair).
    *
    * If any of these checks fail, this function throws an [IllegalArgumentException] with
    * a descriptive error message.
@@ -186,7 +181,7 @@ public object Ed25519 : KeyGenerator, Signer {
    * to safeguard against invalid key usage and potential vulnerabilities.
    *
    * @param key The [JWK] to validate.
-   * @throws IllegalArgumentException if the key is not of type [OctetKeyPair] or if the key type is not [KeyType.EC].
+   * @throws IllegalArgumentException if the key is not of type [OctetKeyPair].
    */
   private fun validateKey(key: JWK) {
     require(key is OctetKeyPair) { "key must be an Octet Key Pair (kty: OKP)" }

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Ed25519.kt
@@ -2,9 +2,7 @@ package web5.sdk.crypto
 
 import com.google.crypto.tink.subtle.Ed25519Sign
 import com.google.crypto.tink.subtle.Ed25519Verify
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
@@ -36,7 +34,7 @@ import java.security.SignatureException
  */
 
 public object Ed25519 : KeyGenerator, Signer {
-  override val algorithm: Algorithm = JWSAlgorithm.EdDSA
+  override val algorithm: Jwa = Jwa.EdDSA
   override val keyType: KeyType = KeyType.OKP
 
   public const val PUB_MULTICODEC: Int = 0xed
@@ -49,7 +47,7 @@ public object Ed25519 : KeyGenerator, Signer {
    * @return The generated private key in JWK format.
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
-    return OctetKeyPairGenerator(Curve.Ed25519)
+    return OctetKeyPairGenerator(JwaCurve.toJwkCurve(JwaCurve.Ed25519))
       .algorithm(JWSAlgorithm.EdDSA)
       .keyIDFromThumbprint(true)
       .keyUse(KeyUse.SIGNATURE)
@@ -88,8 +86,8 @@ public object Ed25519 : KeyGenerator, Signer {
     val base64UrlEncodedPrivateKey = Convert(privateKeyBytes).toBase64Url(padding = false)
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
-    return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm)
+    return OctetKeyPair.Builder(JwaCurve.toJwkCurve(JwaCurve.Ed25519), Base64URL(base64UrlEncodedPublicKey))
+      .algorithm(Jwa.toJwsAlgorithm(algorithm))
       .keyIDFromThumbprint()
       .d(Base64URL(base64UrlEncodedPrivateKey))
       .keyUse(KeyUse.SIGNATURE)
@@ -99,8 +97,8 @@ public object Ed25519 : KeyGenerator, Signer {
   override fun bytesToPublicKey(publicKeyBytes: ByteArray): JWK {
     val base64UrlEncodedPublicKey = Convert(publicKeyBytes).toBase64Url(padding = false)
 
-    return OctetKeyPair.Builder(Curve.Ed25519, Base64URL(base64UrlEncodedPublicKey))
-      .algorithm(algorithm)
+    return OctetKeyPair.Builder(JwaCurve.toJwkCurve(JwaCurve.Ed25519), Base64URL(base64UrlEncodedPublicKey))
+      .algorithm(Jwa.toJwsAlgorithm(algorithm))
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
       .build()

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -29,14 +29,12 @@ public class InMemoryKeyManager : KeyManager {
   private val keyStore: MutableMap<String, JWK> = HashMap()
 
   /**
-   * Generates a private key using specified algorithm and curve, and stores it in the in-memory keyStore.
+   * Generates a private key using specified algorithmId, and stores it in the in-memory keyStore.
    *
-   * @param algorithm The JWA algorithm identifier.
-   * @param curve The elliptic curve. Null for algorithms that do not use elliptic curves.
+   * @param algorithmId The algorithmId [AlgorithmId].
    * @param options Options for key generation, may include specific parameters relevant to the algorithm.
    * @return The key ID of the generated private key.
    */
-  // TODO: have caller call in with AlgorithmId instead of algorithm + curve combo?
   override fun generatePrivateKey(algorithmId: AlgorithmId, options: KeyGenOptions?): String {
     val jwk = Crypto.generatePrivateKey(algorithmId, options)
     keyStore[jwk.keyID] = jwk

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -1,7 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
 /**
@@ -38,7 +36,8 @@ public class InMemoryKeyManager : KeyManager {
    * @param options Options for key generation, may include specific parameters relevant to the algorithm.
    * @return The key ID of the generated private key.
    */
-  override fun generatePrivateKey(algorithm: Algorithm, curve: Curve?, options: KeyGenOptions?): String {
+  // TODO: have caller call in with AlgorithmId instead of algorithm + curve combo?
+  override fun generatePrivateKey(algorithm: Jwa, curve: JwaCurve?, options: KeyGenOptions?): String {
     val jwk = Crypto.generatePrivateKey(algorithm, curve, options)
     keyStore[jwk.keyID] = jwk
 

--- a/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/InMemoryKeyManager.kt
@@ -37,8 +37,8 @@ public class InMemoryKeyManager : KeyManager {
    * @return The key ID of the generated private key.
    */
   // TODO: have caller call in with AlgorithmId instead of algorithm + curve combo?
-  override fun generatePrivateKey(algorithm: Jwa, curve: JwaCurve?, options: KeyGenOptions?): String {
-    val jwk = Crypto.generatePrivateKey(algorithm, curve, options)
+  override fun generatePrivateKey(algorithmId: AlgorithmId, options: KeyGenOptions?): String {
+    val jwk = Crypto.generatePrivateKey(algorithmId, options)
     keyStore[jwk.keyID] = jwk
 
     return jwk.keyID

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
@@ -1,7 +1,6 @@
 package web5.sdk.crypto
 
 import com.nimbusds.jose.jwk.JWK
-import com.nimbusds.jose.jwk.KeyType
 
 /**
  * `KeyGenOptions` serves as an interface defining options or parameters that influence
@@ -64,9 +63,6 @@ public interface KeyGenOptions
 public interface KeyGenerator {
   /**  Indicates the algorithm intended to be used with the key. */
   public val algorithm: Jwa
-
-  /** Indicates the cryptographic algorithm family used with the key. */
-  public val keyType: KeyType
 
   /** Generates a private key. */
   public fun generatePrivateKey(options: KeyGenOptions? = null): JWK

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
@@ -64,6 +64,12 @@ public interface KeyGenerator {
   /**  Indicates the algorithm intended to be used with the key. */
   public val algorithm: Jwa
 
+  /** KeyType in String format (OKP, EC, etc.). */
+  public val keyType: String
+
+  /** The curve used for the key generation. */
+  public val curve: JwaCurve
+
   /** Generates a private key. */
   public fun generatePrivateKey(options: KeyGenOptions? = null): JWK
 

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyGenerator.kt
@@ -1,6 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
 
@@ -64,7 +63,7 @@ public interface KeyGenOptions
  */
 public interface KeyGenerator {
   /**  Indicates the algorithm intended to be used with the key. */
-  public val algorithm: Algorithm
+  public val algorithm: Jwa
 
   /** Indicates the cryptographic algorithm family used with the key. */
   public val keyType: KeyType

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -18,17 +18,14 @@ public interface KeyManager {
    * Generates and securely stores a private key based on the provided algorithm and options,
    * returning a unique alias that can be utilized to reference the generated key for future operations.
    *
-   * @param algorithm The cryptographic algorithm to use for key generation.
-   * @param curve (Optional) The elliptic curve to use (relevant for EC algorithms).
+   * @param algorithmId The algorithmId to use for key generation.
    * @param options (Optional) Additional options to control key generation behavior.
    * @return A unique alias (String) that can be used to reference the stored key.
    *
    * Implementations should ensure secure storage of the generated keys, protecting against
    * unauthorized access and ensuring cryptographic strength according to the provided parameters.
    */
-  public fun generatePrivateKey(
-    algorithmId: AlgorithmId,
-    options: KeyGenOptions? = null): String
+  public fun generatePrivateKey(algorithmId: AlgorithmId, options: KeyGenOptions? = null): String
 
   /**
    * Retrieves the public key associated with a previously stored private key, identified by the provided alias.

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -1,7 +1,5 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 
 /**
@@ -28,7 +26,10 @@ public interface KeyManager {
    * Implementations should ensure secure storage of the generated keys, protecting against
    * unauthorized access and ensuring cryptographic strength according to the provided parameters.
    */
-  public fun generatePrivateKey(algorithm: Algorithm, curve: Curve? = null, options: KeyGenOptions? = null): String
+  public fun generatePrivateKey(
+    algorithm: Jwa,
+    curve: JwaCurve? = null,
+    options: KeyGenOptions? = null): String
 
   /**
    * Retrieves the public key associated with a previously stored private key, identified by the provided alias.

--- a/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/KeyManager.kt
@@ -27,8 +27,7 @@ public interface KeyManager {
    * unauthorized access and ensuring cryptographic strength according to the provided parameters.
    */
   public fun generatePrivateKey(
-    algorithm: Jwa,
-    curve: JwaCurve? = null,
+    algorithmId: AlgorithmId,
     options: KeyGenOptions? = null): String
 
   /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -1,9 +1,7 @@
 package web5.sdk.crypto
 
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyType
@@ -61,7 +59,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     Security.addProvider(BouncyCastleProviderSingleton.getInstance())
   }
 
-  override val algorithm: Algorithm = JWSAlgorithm.ES256K
+  override val algorithm: Jwa = Jwa.ES256K
   override val keyType: KeyType = KeyType.EC
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
@@ -140,7 +138,7 @@ public object Secp256k1 : KeyGenerator, Signer {
    * @return A JWK representing the generated private key.
    */
   override fun generatePrivateKey(options: KeyGenOptions?): JWK {
-    return ECKeyGenerator(Curve.SECP256K1)
+    return ECKeyGenerator(com.nimbusds.jose.jwk.Curve.SECP256K1)
       .algorithm(JWSAlgorithm.ES256K)
       .provider(BouncyCastleProviderSingleton.getInstance())
       .keyIDFromThumbprint(true)
@@ -177,7 +175,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val rawX = pointQ.rawXCoord.encoded
     val rawY = pointQ.rawYCoord.encoded
 
-    return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(rawX), Base64URL.encode(rawY))
+    return ECKey.Builder(com.nimbusds.jose.jwk.Curve.SECP256K1, Base64URL.encode(rawX), Base64URL.encode(rawY))
       .algorithm(JWSAlgorithm.ES256K)
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)
@@ -188,7 +186,7 @@ public object Secp256k1 : KeyGenerator, Signer {
     val xBytes = publicKeyBytes.sliceArray(1..32)
     val yBytes = publicKeyBytes.sliceArray(33..64)
 
-    return ECKey.Builder(Curve.SECP256K1, Base64URL.encode(xBytes), Base64URL.encode(yBytes))
+    return ECKey.Builder(com.nimbusds.jose.jwk.Curve.SECP256K1, Base64URL.encode(xBytes), Base64URL.encode(yBytes))
       .algorithm(JWSAlgorithm.ES256K)
       .keyIDFromThumbprint()
       .keyUse(KeyUse.SIGNATURE)

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -4,7 +4,6 @@ import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
-import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.util.Base64URL
@@ -60,7 +59,6 @@ public object Secp256k1 : KeyGenerator, Signer {
   }
 
   override val algorithm: Jwa = Jwa.ES256K
-  override val keyType: KeyType = KeyType.EC
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
   public const val PUB_MULTICODEC: Int = 0xe7
@@ -294,7 +292,6 @@ public object Secp256k1 : KeyGenerator, Signer {
    *
    * This function checks the following:
    * - The key must be an instance of [ECKey].
-   * - The key type (`kty`) must be [KeyType.EC] (Elliptic Curve).
    *
    * If any of these checks fail, this function throws an [IllegalArgumentException] with
    * a descriptive error message.
@@ -315,11 +312,10 @@ public object Secp256k1 : KeyGenerator, Signer {
    * to safeguard against invalid key usage and potential vulnerabilities.
    *
    * @param key The [JWK] to validate.
-   * @throws IllegalArgumentException if the key is not of type [ECKey] or if the key type is not [KeyType.EC].
+   * @throws IllegalArgumentException if the key is not of type [ECKey].
    */
   public fun validateKey(key: JWK) {
     require(key is ECKey) { "private key must be an ECKey (kty: EC)" }
-    require(key.keyType == keyType) { "private key key type must be EC" }
   }
 
   /**

--- a/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
+++ b/crypto/src/main/kotlin/web5/sdk/crypto/Secp256k1.kt
@@ -59,6 +59,8 @@ public object Secp256k1 : KeyGenerator, Signer {
   }
 
   override val algorithm: Jwa = Jwa.ES256K
+  override val curve: JwaCurve = JwaCurve.secp256k1
+  override val keyType: String = "EC"
 
   /** [reference](https://github.com/multiformats/multicodec/blob/master/table.csv#L92). */
   public const val PUB_MULTICODEC: Int = 0xe7

--- a/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
@@ -20,7 +20,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test key generation`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val publicKey = awsKeyManager.getPublicKey(alias)
 
     assertEquals(alias, publicKey.keyID)
@@ -33,7 +33,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test alias is stable`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val publicKey = awsKeyManager.getPublicKey(alias)
     val defaultAlias = awsKeyManager.getDeterministicAlias(publicKey)
 
@@ -44,7 +44,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test signing`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val signature = awsKeyManager.sign(alias, signingInput)
 
     //Verify the signature with BouncyCastle via Crypto
@@ -64,7 +64,7 @@ class AwsKeyManagerTest {
     val customisedKeyManager = AwsKeyManager(kmsClient = kmsClient)
 
     assertThrows<AmazonServiceException> {
-      customisedKeyManager.generatePrivateKey(Jwa.ES256K)
+      customisedKeyManager.generatePrivateKey(AlgorithmId.secp256k1)
     }
   }
 }

--- a/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
@@ -5,12 +5,13 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.kms.AWSKMSClient
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.KeyType
+import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.KeyUse
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AwsKeyManagerTest {
 
@@ -24,7 +25,7 @@ class AwsKeyManagerTest {
     val publicKey = awsKeyManager.getPublicKey(alias)
 
     assertEquals(alias, publicKey.keyID)
-    assertEquals(KeyType.EC, publicKey.keyType)
+    assertTrue(publicKey is ECKey)
     assertEquals(KeyUse.SIGNATURE, publicKey.keyUse)
     assertEquals(JWSAlgorithm.ES256K, publicKey.algorithm)
   }

--- a/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/AwsKeyManagerTest.kt
@@ -20,7 +20,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test key generation`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
     val publicKey = awsKeyManager.getPublicKey(alias)
 
     assertEquals(alias, publicKey.keyID)
@@ -33,7 +33,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test alias is stable`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
     val publicKey = awsKeyManager.getPublicKey(alias)
     val defaultAlias = awsKeyManager.getDeterministicAlias(publicKey)
 
@@ -44,7 +44,7 @@ class AwsKeyManagerTest {
   @Disabled("Needs an AWS connection")
   fun `test signing`() {
     val awsKeyManager = AwsKeyManager()
-    val alias = awsKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = awsKeyManager.generatePrivateKey(Jwa.ES256K)
     val signature = awsKeyManager.sign(alias, signingInput)
 
     //Verify the signature with BouncyCastle via Crypto
@@ -64,7 +64,7 @@ class AwsKeyManagerTest {
     val customisedKeyManager = AwsKeyManager(kmsClient = kmsClient)
 
     assertThrows<AmazonServiceException> {
-      customisedKeyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+      customisedKeyManager.generatePrivateKey(Jwa.ES256K)
     }
   }
 }

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -18,7 +18,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `test alias is consistent`() {
     val keyManager = InMemoryKeyManager()
-    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
+    val alias = keyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val publicKey = keyManager.getPublicKey(alias)
     val defaultAlias = keyManager.getDeterministicAlias(publicKey)
 
@@ -28,7 +28,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `exception is thrown when kid not found`() {
     val keyManager = InMemoryKeyManager()
-    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
+    val jwk = Crypto.generatePrivateKey(AlgorithmId.secp256k1)
     val exception = assertThrows<IllegalArgumentException> {
       keyManager.getDeterministicAlias(jwk.toPublicJWK())
     }
@@ -37,7 +37,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public key is available after import`() {
-    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
+    val jwk = Crypto.generatePrivateKey(AlgorithmId.secp256k1)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk)
@@ -48,7 +48,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public keys can be imported`() {
-    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
+    val jwk = Crypto.generatePrivateKey(AlgorithmId.secp256k1)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk.toPublicJWK())
@@ -56,6 +56,7 @@ class InMemoryKeyManagerTest {
     assertEquals(jwk.toPublicJWK(), keyManager.getPublicKey(alias))
   }
 
+  // todo should this test actually assert an exception thrown?
   @Test
   fun `key without kid can be imported`() {
     val jwk = ECKeyGenerator(Curve.SECP256K1)
@@ -74,7 +75,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `export returns all keys`() {
     val keyManager = InMemoryKeyManager()
-    keyManager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
+    keyManager.generatePrivateKey(AlgorithmId.Ed25519)
 
     val keySet = keyManager.export()
     assertEquals(1, keySet.size)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -3,7 +3,6 @@ package web5.sdk.crypto
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
@@ -19,7 +18,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `test alias is consistent`() {
     val keyManager = InMemoryKeyManager()
-    val alias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val alias = keyManager.generatePrivateKey(Jwa.ES256K)
     val publicKey = keyManager.getPublicKey(alias)
     val defaultAlias = keyManager.getDeterministicAlias(publicKey)
 
@@ -29,7 +28,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `exception is thrown when kid not found`() {
     val keyManager = InMemoryKeyManager()
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
     val exception = assertThrows<IllegalArgumentException> {
       keyManager.getDeterministicAlias(jwk.toPublicJWK())
     }
@@ -38,7 +37,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public key is available after import`() {
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk)
@@ -49,7 +48,7 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `public keys can be imported`() {
-    val jwk = Crypto.generatePrivateKey(JWSAlgorithm.ES256K)
+    val jwk = Crypto.generatePrivateKey(Jwa.ES256K)
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk.toPublicJWK())
@@ -59,7 +58,11 @@ class InMemoryKeyManagerTest {
 
   @Test
   fun `key without kid can be imported`() {
-    val jwk = ECKeyGenerator(Curve.SECP256K1).provider(BouncyCastleProviderSingleton.getInstance()).generate()
+    val jwk = ECKeyGenerator(Curve.SECP256K1)
+      .provider(
+        BouncyCastleProviderSingleton.getInstance()
+      )
+      .generate()
     val keyManager = InMemoryKeyManager()
 
     val alias = keyManager.import(jwk)
@@ -71,7 +74,7 @@ class InMemoryKeyManagerTest {
   @Test
   fun `export returns all keys`() {
     val keyManager = InMemoryKeyManager()
-    keyManager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+    keyManager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
 
     val keySet = keyManager.export()
     assertEquals(1, keySet.size)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/InMemoryKeyManagerTest.kt
@@ -56,7 +56,6 @@ class InMemoryKeyManagerTest {
     assertEquals(jwk.toPublicJWK(), keyManager.getPublicKey(alias))
   }
 
-  // todo should this test actually assert an exception thrown?
   @Test
   fun `key without kid can be imported`() {
     val jwk = ECKeyGenerator(Curve.SECP256K1)

--- a/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
+++ b/crypto/src/test/kotlin/web5/sdk/crypto/Secp256k1Test.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import org.apache.commons.codec.binary.Hex
 import org.junit.jupiter.api.Test
@@ -29,7 +28,7 @@ class Secp256k1Test {
     assertEquals(JWSAlgorithm.ES256K, privateKey.algorithm)
     assertEquals(KeyUse.SIGNATURE, privateKey.keyUse)
     assertNotNull(privateKey.keyID)
-    assertEquals(KeyType.EC, privateKey.keyType)
+    assertTrue(privateKey is ECKey)
     assertTrue(privateKey.isPrivate)
   }
 
@@ -43,7 +42,7 @@ class Secp256k1Test {
     assertEquals(publicKey.keyID, privateKey.keyID)
     assertEquals(JWSAlgorithm.ES256K, publicKey.algorithm)
     assertEquals(KeyUse.SIGNATURE, publicKey.keyUse)
-    assertEquals(KeyType.EC, publicKey.keyType)
+    assertTrue(publicKey is ECKey)
     assertFalse(publicKey.isPrivate)
   }
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -1,6 +1,7 @@
 package web5.sdk.dids.methods.dht
 
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.OctetKeyPair
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
@@ -133,7 +134,8 @@ internal class DhtClient(
       // get the public key to verify it is an Ed25519 key
       val pubKey = manager.getPublicKey(keyAlias)
       require(
-        pubKey.keyType == Ed25519.keyType &&
+        // todo changed this to specifying pubkey keytype, but want to use Ed25519.keyType (now removed)
+        pubKey is OctetKeyPair &&
           pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
       ) {
         "Must supply an Ed25519 key"
@@ -186,7 +188,8 @@ internal class DhtClient(
       // get the public key to verify it is an Ed25519 key
       val pubKey = manager.getPublicKey(keyAlias)
       require(
-        pubKey.keyType == Ed25519.keyType &&
+        // todo changed this to specifying pubkey keytype, but want to use Ed25519.keyType (now removed)
+        pubKey is OctetKeyPair &&
           pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
       ) {
         "Must supply an Ed25519 key"

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -19,6 +19,7 @@ import org.xbill.DNS.Message
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.exceptions.PkarrRecordNotFoundException
 import web5.sdk.dids.exceptions.PkarrRecordResponseException
@@ -133,11 +134,8 @@ internal class DhtClient(
     fun createBep44PutRequest(manager: KeyManager, keyAlias: String, message: Message): Bep44Message {
       // get the public key to verify it is an Ed25519 key
       val pubKey = manager.getPublicKey(keyAlias)
-      require(
-        // todo changed this to specifying pubkey keytype, but want to use Ed25519.keyType (now removed)
-        pubKey is OctetKeyPair &&
-          pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
-      ) {
+      val curve = pubKey.toJSONObject()["crv"]
+      require(curve == Ed25519.curve.name) {
         "Must supply an Ed25519 key"
       }
 
@@ -187,11 +185,9 @@ internal class DhtClient(
     fun signBep44Message(manager: KeyManager, keyAlias: String, seq: Long, v: ByteArray): Bep44Message {
       // get the public key to verify it is an Ed25519 key
       val pubKey = manager.getPublicKey(keyAlias)
-      require(
-        // todo changed this to specifying pubkey keytype, but want to use Ed25519.keyType (now removed)
-        pubKey is OctetKeyPair &&
-          pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
-      ) {
+
+      val curve = pubKey.toJSONObject()["crv"]
+      require(curve == Ed25519.curve.name) {
         "Must supply an Ed25519 key"
       }
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -18,6 +18,7 @@ import org.xbill.DNS.Message
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
+import web5.sdk.crypto.Jwa
 import web5.sdk.dids.exceptions.PkarrRecordNotFoundException
 import web5.sdk.dids.exceptions.PkarrRecordResponseException
 import java.io.ByteArrayOutputStream
@@ -133,7 +134,7 @@ internal class DhtClient(
       val pubKey = manager.getPublicKey(keyAlias)
       require(
         pubKey.keyType == Ed25519.keyType &&
-          pubKey.algorithm == Ed25519.algorithm
+          pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
       ) {
         "Must supply an Ed25519 key"
       }
@@ -186,7 +187,7 @@ internal class DhtClient(
       val pubKey = manager.getPublicKey(keyAlias)
       require(
         pubKey.keyType == Ed25519.keyType &&
-          pubKey.algorithm == Ed25519.algorithm
+          pubKey.algorithm == Jwa.toJwsAlgorithm(Ed25519.algorithm)
       ) {
         "Must supply an Ed25519 key"
       }

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DhtClient.kt
@@ -17,8 +17,8 @@ import org.xbill.DNS.DNSInput
 import org.xbill.DNS.Message
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.Ed25519
-import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.KeyManager
 import web5.sdk.dids.exceptions.PkarrRecordNotFoundException
 import web5.sdk.dids.exceptions.PkarrRecordResponseException
 import java.io.ByteArrayOutputStream

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -18,12 +18,11 @@ import org.xbill.DNS.TXTRecord
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
 import web5.sdk.common.ZBase32
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
-import web5.sdk.crypto.Jwa
-import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidDocumentMetadata
@@ -134,7 +133,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
     val opts = options ?: CreateDidDhtOptions()
 
     // create identity key
-    val keyAlias = keyManager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
+    val keyAlias = keyManager.generatePrivateKey(AlgorithmId.Ed25519)
     val publicKey = keyManager.getPublicKey(keyAlias)
 
     // build DID Document

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -1,7 +1,6 @@
 package web5.sdk.dids.methods.dht
 
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
@@ -23,6 +22,8 @@ import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidDocumentMetadata
@@ -133,7 +134,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
     val opts = options ?: CreateDidDhtOptions()
 
     // create identity key
-    val keyAlias = keyManager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+    val keyAlias = keyManager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
     val publicKey = keyManager.getPublicKey(keyAlias)
 
     // build DID Document

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -798,7 +798,7 @@ private interface VerificationMethodGenerator {
 
 /**
  * A [VerificationMethodSpec] where a [KeyManager] will be used to generate the underlying verification method keys.
- * The parameters [algorithm], [curve], and [options] will be forwarded to the keyManager.
+ * The parameters [algorithmId] and [options] will be forwarded to the keyManager.
  *
  * [relationships] will be used to determine the verification relationships in the DID Document being created.
  * */

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/ion/DidIon.kt
@@ -1,12 +1,10 @@
 package web5.sdk.dids.methods.ion
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.nimbusds.jose.Algorithm
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSObject
 import com.nimbusds.jose.Payload
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.util.Base64URL
 import foundation.identity.did.DID
@@ -29,6 +27,8 @@ import web5.sdk.common.Convert
 import web5.sdk.common.Varint
 import web5.sdk.crypto.KeyGenOptions
 import web5.sdk.crypto.KeyManager
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.CreationMetadata
 import web5.sdk.dids.Did
@@ -357,7 +357,7 @@ public sealed class DidIonApi(
     }
     val updatePublicKey = keyManager.getPublicKey(options.updateKeyAlias)
 
-    val newUpdateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val newUpdateKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
     val newUpdatePublicKey = keyManager.getPublicKey(newUpdateKeyAlias)
 
     val reveal = updatePublicKey.reveal()
@@ -444,7 +444,7 @@ public sealed class DidIonApi(
 
   internal fun createOperation(keyManager: KeyManager, options: CreateDidIonOptions?)
     : Pair<SidetreeCreateOperation, KeyAliases> {
-    val updateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val updateKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
     val updatePublicJwk = keyManager.getPublicKey(updateKeyAlias)
 
     val publicKeyCommitment = updatePublicJwk.commitment()
@@ -460,7 +460,7 @@ public sealed class DidIonApi(
       updateCommitment = publicKeyCommitment
     )
 
-    val recoveryKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val recoveryKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
     val recoveryPublicJwk = keyManager.getPublicKey(recoveryKeyAlias)
     val recoveryCommitment = recoveryPublicJwk.commitment()
 
@@ -485,7 +485,7 @@ public sealed class DidIonApi(
     if (options == null || options.verificationMethodsToAdd.count() == 0) {
       listOf<VerificationMethodSpec>(
         VerificationMethodCreationParams(
-          JWSAlgorithm.ES256K,
+          Jwa.ES256K,
           relationships = listOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD)
         )
       ).toPublicKeys(keyManager)
@@ -546,11 +546,11 @@ public sealed class DidIonApi(
     val recoveryPublicKey = keyManager.getPublicKey(options.recoveryKeyAlias)
     val reveal = recoveryPublicKey.reveal()
 
-    val nextRecoveryKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val nextRecoveryKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
     val nextRecoveryPublicKey = keyManager.getPublicKey(nextRecoveryKeyAlias)
     val nextRecoveryCommitment = nextRecoveryPublicKey.commitment()
 
-    val nextUpdateKeyAlias = keyManager.generatePrivateKey(JWSAlgorithm.ES256K)
+    val nextUpdateKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
     val nextUpdatePublicKey = keyManager.getPublicKey(nextUpdateKeyAlias)
     val nextUpdateCommitment = nextUpdatePublicKey.commitment()
 
@@ -804,8 +804,8 @@ private interface VerificationMethodGenerator {
  * [relationships] will be used to determine the verification relationships in the DID Document being created.
  * */
 public class VerificationMethodCreationParams(
-  public val algorithm: Algorithm,
-  public val curve: Curve? = null,
+  public val algorithm: Jwa,
+  public val curve: JwaCurve? = null,
   public val options: KeyGenOptions? = null,
   public val relationships: Iterable<PublicKeyPurpose>
 ) : VerificationMethodSpec {

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -8,9 +8,8 @@ import foundation.identity.did.VerificationMethod
 import foundation.identity.did.parser.ParserException
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.KeyManager
-import web5.sdk.crypto.Jwa
-import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
@@ -39,8 +38,7 @@ import java.text.ParseException
  * ```
  */
 public class CreateDidJwkOptions(
-  public val algorithm: Jwa = Jwa.ES256K,
-  public val curve: JwaCurve? = null
+  public val algorithmId: AlgorithmId? = AlgorithmId.secp256k1,
 ) : CreateDidOptions
 
 /**
@@ -90,7 +88,8 @@ public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
     override fun create(keyManager: KeyManager, options: CreateDidJwkOptions?): DidJwk {
       val opts = options ?: CreateDidJwkOptions()
 
-      val keyAlias = keyManager.generatePrivateKey(opts.algorithm, opts.curve)
+      // todo do i need this null coalescing?
+      val keyAlias = keyManager.generatePrivateKey(opts.algorithmId ?: AlgorithmId.secp256k1)
       val publicKey = keyManager.getPublicKey(keyAlias)
 
       val base64Encoded = Convert(publicKey.toJSONString()).toBase64Url(padding = false)

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -1,8 +1,5 @@
 package web5.sdk.dids.methods.jwk
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
 import foundation.identity.did.DID
@@ -12,6 +9,8 @@ import foundation.identity.did.parser.ParserException
 import web5.sdk.common.Convert
 import web5.sdk.common.EncodingFormat
 import web5.sdk.crypto.KeyManager
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
@@ -40,8 +39,8 @@ import java.text.ParseException
  * ```
  */
 public class CreateDidJwkOptions(
-  public val algorithm: Algorithm = JWSAlgorithm.ES256K,
-  public val curve: Curve? = null
+  public val algorithm: Jwa = Jwa.ES256K,
+  public val curve: JwaCurve? = null
 ) : CreateDidOptions
 
 /**

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -80,7 +80,7 @@ public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
      * **Note**: Defaults to ES256K if no options are provided
      *
      * @param keyManager A [KeyManager] instance where the new key will be stored.
-     * @param options Optional parameters ([CreateDidJwkOptions]) to specify algorithm and curve during key creation.
+     * @param options Optional parameters ([CreateDidJwkOptions]) to specify algorithmId during key creation.
      * @return A [DidJwk] instance representing the newly created "did:jwk" DID.
      *
      * @throws UnsupportedOperationException if the specified curve is not supported.
@@ -88,7 +88,7 @@ public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
     override fun create(keyManager: KeyManager, options: CreateDidJwkOptions?): DidJwk {
       val opts = options ?: CreateDidJwkOptions()
 
-      // todo do i need this null coalescing?
+      // todo do i need this null coalescing? it's there by default during CreateDidJwkOptions constructor.
       val keyAlias = keyManager.generatePrivateKey(opts.algorithmId ?: AlgorithmId.secp256k1)
       val publicKey = keyManager.getPublicKey(keyAlias)
 

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/jwk/DidJwk.kt
@@ -24,11 +24,8 @@ import java.text.ParseException
 /**
  * Specifies options for creating a new "did:jwk" Decentralized Identifier (DID).
  *
- * @property algorithm Specifies the algorithm to be used for key creation.
+ * @property algorithmId Specifies the algorithmId to be used for key creation.
  *                     Defaults to ES256K (Elliptic Curve Digital Signature Algorithm with SHA-256 and secp256k1 curve).
- * @property curve Specifies the elliptic curve to be used with the algorithm.
- *                 Optional and can be null if the algorithm does not require an explicit curve specification.
- *
  * @constructor Creates an instance of [CreateDidJwkOptions] with the provided [algorithm] and [curve].
  *
  * ### Usage Example:
@@ -38,7 +35,7 @@ import java.text.ParseException
  * ```
  */
 public class CreateDidJwkOptions(
-  public val algorithmId: AlgorithmId? = AlgorithmId.secp256k1,
+  public val algorithmId: AlgorithmId = AlgorithmId.secp256k1,
 ) : CreateDidOptions
 
 /**
@@ -88,8 +85,7 @@ public class DidJwk(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
     override fun create(keyManager: KeyManager, options: CreateDidJwkOptions?): DidJwk {
       val opts = options ?: CreateDidJwkOptions()
 
-      // todo do i need this null coalescing? it's there by default during CreateDidJwkOptions constructor.
-      val keyAlias = keyManager.generatePrivateKey(opts.algorithmId ?: AlgorithmId.secp256k1)
+      val keyAlias = keyManager.generatePrivateKey(opts.algorithmId)
       val publicKey = keyManager.getPublicKey(keyAlias)
 
       val base64Encoded = Convert(publicKey.toJSONString()).toBase64Url(padding = false)

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -20,12 +20,9 @@ import java.net.URI
 /**
  * Specifies options for creating a new "did:key" Decentralized Identifier (DID).
  *
- * @property algorithm Specifies the algorithm to be used for key creation.
- *                     Defaults to ES256K (Elliptic Curve Digital Signature Algorithm with SHA-256 and secp256k1 curve).
- * @property curve Specifies the elliptic curve to be used with the algorithm.
- *                 Optional and can be null if the algorithm does not require an explicit curve specification.
- *
- * @constructor Creates an instance of [CreateDidKeyOptions] with the provided [algorithm] and [curve].
+ * @property algorithmId Specifies the algorithmId to be used for key creation.
+ *                       Defaults to ES256K (Elliptic Curve Digital Signature Algorithm with SHA-256 and secp256k1 curve).
+ * @constructor Creates an instance of [CreateDidKeyOptions] with the provided [algorithmId].
  *
  * ### Usage Example:
  * ```
@@ -75,7 +72,7 @@ public class DidKey(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
      * **Note**: Defaults to ES256K if no options are provided
      *
      * @param keyManager A [KeyManager] instance where the new key will be stored.
-     * @param options Optional parameters ([CreateDidKeyOptions]) to specify algorithm and curve during key creation.
+     * @param options Optional parameters ([CreateDidKeyOptions]) to specify algorithmId during key creation.
      * @return A [DidKey] instance representing the newly created "did:key" DID.
      *
      * @throws UnsupportedOperationException if the specified curve is not supported.

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -5,11 +5,10 @@ import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
 import io.ipfs.multibase.Multibase
 import web5.sdk.common.Varint
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
-import web5.sdk.crypto.Jwa
-import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
@@ -35,8 +34,7 @@ import java.net.URI
  * ```
  */
 public class CreateDidKeyOptions(
-  public val algorithm: Jwa = Jwa.ES256K,
-  public val curve: JwaCurve? = null
+  public val algorithmId: AlgorithmId = AlgorithmId.secp256k1,
 ) : CreateDidOptions
 
 /**
@@ -85,16 +83,16 @@ public class DidKey(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
     override fun create(keyManager: KeyManager, options: CreateDidKeyOptions?): DidKey {
       val opts = options ?: CreateDidKeyOptions()
 
-      val keyAlias = keyManager.generatePrivateKey(opts.algorithm, opts.curve)
+      val keyAlias = keyManager.generatePrivateKey(opts.algorithmId)
       val publicKey = keyManager.getPublicKey(keyAlias)
       var publicKeyBytes = Crypto.publicKeyToBytes(publicKey)
 
-      if (opts.algorithm == Jwa.ES256K) {
+      if (opts.algorithmId == AlgorithmId.secp256k1) {
         publicKeyBytes = Secp256k1.compressPublicKey(publicKeyBytes)
       }
 
-      val multiCodec = Crypto.getAlgorithmMultiCodec(opts.algorithm, opts.curve)
-        ?: throw UnsupportedOperationException("${opts.curve} curve not supported")
+      val multiCodec = Crypto.getAlgorithmMultiCodec(opts.algorithmId)
+        ?: throw UnsupportedOperationException("${opts.algorithmId.curveName} curve not supported")
 
       val multiCodecBytes = Varint.encode(multiCodec)
       val idBytes = multiCodecBytes + publicKeyBytes

--- a/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/key/DidKey.kt
@@ -1,8 +1,5 @@
 package web5.sdk.dids.methods.key
 
-import com.nimbusds.jose.Algorithm
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.Curve
 import foundation.identity.did.DID
 import foundation.identity.did.DIDDocument
 import foundation.identity.did.VerificationMethod
@@ -11,6 +8,8 @@ import web5.sdk.common.Varint
 import web5.sdk.crypto.Crypto
 import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.Secp256k1
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.CreateDidOptions
 import web5.sdk.dids.Did
 import web5.sdk.dids.DidMethod
@@ -36,8 +35,8 @@ import java.net.URI
  * ```
  */
 public class CreateDidKeyOptions(
-  public val algorithm: Algorithm = JWSAlgorithm.ES256K,
-  public val curve: Curve? = null
+  public val algorithm: Jwa = Jwa.ES256K,
+  public val curve: JwaCurve? = null
 ) : CreateDidOptions
 
 /**
@@ -90,7 +89,7 @@ public class DidKey(uri: String, keyManager: KeyManager) : Did(uri, keyManager) 
       val publicKey = keyManager.getPublicKey(keyAlias)
       var publicKeyBytes = Crypto.publicKeyToBytes(publicKey)
 
-      if (opts.algorithm == JWSAlgorithm.ES256K) {
+      if (opts.algorithm == Jwa.ES256K) {
         publicKeyBytes = Secp256k1.compressPublicKey(publicKeyBytes)
       }
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
@@ -9,10 +9,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.Secp256k1
-import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.methods.dht.DhtClient.Companion.bencode
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -97,7 +96,7 @@ class DhtTest {
     @Test
     fun `sign and verify a BEP44 message`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Ed25519.algorithm, JwaCurve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(AlgorithmId.Ed25519)
 
       val seq = 1L
       val v = "Hello World!".toByteArray()
@@ -120,7 +119,7 @@ class DhtTest {
     @Test
     fun `sign BEP44 message with wrong key type`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Secp256k1.algorithm, JwaCurve.SECP256K1)
+      val keyAlias = manager.generatePrivateKey(AlgorithmId.secp256k1)
 
       val seq = 1L
       val v = "Hello World!".toByteArray()

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DhtTest.kt
@@ -1,6 +1,5 @@
 package web5.sdk.dids.methods.dht
 
-import com.nimbusds.jose.jwk.Curve
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpMethod
@@ -13,6 +12,7 @@ import org.junit.jupiter.api.assertThrows
 import web5.sdk.crypto.Ed25519
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Secp256k1
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.methods.dht.DhtClient.Companion.bencode
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -97,7 +97,7 @@ class DhtTest {
     @Test
     fun `sign and verify a BEP44 message`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Ed25519.algorithm, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Ed25519.algorithm, JwaCurve.Ed25519)
 
       val seq = 1L
       val v = "Hello World!".toByteArray()
@@ -120,7 +120,7 @@ class DhtTest {
     @Test
     fun `sign BEP44 message with wrong key type`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Secp256k1.algorithm, Curve.SECP256K1)
+      val keyAlias = manager.generatePrivateKey(Secp256k1.algorithm, JwaCurve.SECP256K1)
 
       val seq = 1L
       val v = "Hello World!".toByteArray()

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
@@ -2,7 +2,6 @@ package web5.sdk.dids.methods.dht
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
@@ -23,6 +22,8 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import web5.sdk.common.ZBase32
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.exceptions.InvalidIdentifierException
@@ -42,7 +43,7 @@ class DidDhtTest {
     @Test
     fun `did dht identifier`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
 
       val identifier = DidDht.getDidIdentifier(publicKey)
@@ -56,7 +57,7 @@ class DidDhtTest {
     @Test
     fun `validate identity key`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
       val identifier = DidDht.getDidIdentifier(publicKey)
 
@@ -114,7 +115,7 @@ class DidDhtTest {
     fun `create with another key and service`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(JWSAlgorithm.ES256K, Curve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(Jwa.ES256K, JwaCurve.SECP256K1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val publicKeyJwk2 = ECKeyGenerator(Curve.P_256).generate().toPublicJWK()
       val verificationMethodsToAdd: Iterable<Triple<JWK, Array<PublicKeyPurpose>, String?>> = listOf(
@@ -272,7 +273,7 @@ class DidDhtTest {
     fun `to and from DNS packet - complex DID`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(JWSAlgorithm.ES256K, Curve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(Jwa.ES256K, JwaCurve.SECP256K1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val verificationMethodsToAdd: Iterable<Triple<JWK, Array<PublicKeyPurpose>, String?>> = listOf(
         Triple(publicKeyJwk, arrayOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD), null)
@@ -366,7 +367,7 @@ class Web5TestVectorsDidDht {
     testVectors.vectors.forEach { vector ->
       val keyManager = spy(InMemoryKeyManager())
       val identityKeyId = keyManager.import(listOf(vector.input.identityPublicJwk!!)).first()
-      doReturn(identityKeyId).whenever(keyManager).generatePrivateKey(JWSAlgorithm.EdDSA, Curve.Ed25519)
+      doReturn(identityKeyId).whenever(keyManager).generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
 
       val verificationMethods = vector.input.additionalVerificationMethods?.map { verificationMethodInput ->
         val jwk = JWK.parse(verificationMethodInput.jwk)

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/dht/DidDhtTest.kt
@@ -21,9 +21,8 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import web5.sdk.common.ZBase32
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.Jwa
-import web5.sdk.crypto.JwaCurve
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.exceptions.InvalidIdentifierException
@@ -43,7 +42,7 @@ class DidDhtTest {
     @Test
     fun `did dht identifier`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(AlgorithmId.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
 
       val identifier = DidDht.getDidIdentifier(publicKey)
@@ -57,7 +56,7 @@ class DidDhtTest {
     @Test
     fun `validate identity key`() {
       val manager = InMemoryKeyManager()
-      val keyAlias = manager.generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
+      val keyAlias = manager.generatePrivateKey(AlgorithmId.Ed25519)
       val publicKey = manager.getPublicKey(keyAlias)
       val identifier = DidDht.getDidIdentifier(publicKey)
 
@@ -115,7 +114,7 @@ class DidDhtTest {
     fun `create with another key and service`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(Jwa.ES256K, JwaCurve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(AlgorithmId.secp256k1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val publicKeyJwk2 = ECKeyGenerator(Curve.P_256).generate().toPublicJWK()
       val verificationMethodsToAdd: Iterable<Triple<JWK, Array<PublicKeyPurpose>, String?>> = listOf(
@@ -273,7 +272,7 @@ class DidDhtTest {
     fun `to and from DNS packet - complex DID`() {
       val manager = InMemoryKeyManager()
 
-      val otherKey = manager.generatePrivateKey(Jwa.ES256K, JwaCurve.SECP256K1)
+      val otherKey = manager.generatePrivateKey(AlgorithmId.secp256k1)
       val publicKeyJwk = manager.getPublicKey(otherKey).toPublicJWK()
       val verificationMethodsToAdd: Iterable<Triple<JWK, Array<PublicKeyPurpose>, String?>> = listOf(
         Triple(publicKeyJwk, arrayOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD), null)
@@ -367,7 +366,7 @@ class Web5TestVectorsDidDht {
     testVectors.vectors.forEach { vector ->
       val keyManager = spy(InMemoryKeyManager())
       val identityKeyId = keyManager.import(listOf(vector.input.identityPublicJwk!!)).first()
-      doReturn(identityKeyId).whenever(keyManager).generatePrivateKey(Jwa.EdDSA, JwaCurve.Ed25519)
+      doReturn(identityKeyId).whenever(keyManager).generatePrivateKey(AlgorithmId.Ed25519)
 
       val verificationMethods = vector.input.additionalVerificationMethods?.map { verificationMethodInput ->
         val jwk = JWK.parse(verificationMethodInput.jwk)

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/ion/DidIonTest.kt
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
-import web5.sdk.crypto.Jwa
 import web5.sdk.dids.PublicKeyPurpose
 import web5.sdk.dids.methods.ion.models.PublicKey
 import web5.sdk.dids.methods.ion.models.Service
@@ -167,11 +167,11 @@ class DidIonTest {
     val verificationKey = readKey("src/test/resources/verification_jwk.json")
     val updateKey = readKey("src/test/resources/update_jwk.json")
     val updateKeyId = keyManager.import(updateKey)
-    doReturn(updateKeyId).whenever(keyManager).generatePrivateKey(Jwa.ES256K)
+    doReturn(updateKeyId).whenever(keyManager).generatePrivateKey(AlgorithmId.secp256k1)
 
     val recoveryKey = readKey("src/test/resources/recovery_jwk.json")
     val recoveryKeyId = keyManager.import(recoveryKey)
-    doReturn(recoveryKeyId).whenever(keyManager).generatePrivateKey(Jwa.ES256K)
+    doReturn(recoveryKeyId).whenever(keyManager).generatePrivateKey(AlgorithmId.secp256k1)
 
     val didIonApi = DidIonApi {
       ionHost = "madeuphost"
@@ -224,11 +224,11 @@ class DidIonTest {
       keyManager, CreateDidIonOptions(
       verificationMethodsToAdd = listOf(
         VerificationMethodCreationParams(
-          Jwa.ES256K,
+          AlgorithmId.secp256k1,
           relationships = listOf(PublicKeyPurpose.AUTHENTICATION, PublicKeyPurpose.ASSERTION_METHOD)
         ),
         VerificationMethodCreationParams(
-          Jwa.ES256K,
+          AlgorithmId.secp256k1,
           relationships = listOf(PublicKeyPurpose.ASSERTION_METHOD)
         ),
       )
@@ -249,10 +249,10 @@ class DidIonTest {
   @Test
   fun `update throws exception when given invalid input`() {
     val keyManager = InMemoryKeyManager()
-    val keyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
+    val keyAlias = keyManager.generatePrivateKey(AlgorithmId.secp256k1)
     val publicKey = keyManager.getPublicKey(keyAlias)
 
-    val updateKeyAlias = keyManager.generatePrivateKey(Jwa.ES256K)
+    val updateKeyAlias = keyManager.generatePrivateKey(AlgorithmId.secp256k1)
 
     class TestCase(
       val services: Iterable<Service> = emptyList(),
@@ -350,7 +350,7 @@ class DidIonTest {
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k2Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
 
-    doReturn(nextUpdateKeyId, recoveryKeyAlias).whenever(keyManager).generatePrivateKey(Jwa.ES256K)
+    doReturn(nextUpdateKeyId, recoveryKeyAlias).whenever(keyManager).generatePrivateKey(AlgorithmId.secp256k1)
 
     val (result, _) = DidIon.createOperation(
       keyManager,
@@ -390,7 +390,7 @@ class DidIonTest {
 
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k2Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
-    doReturn(nextUpdateKeyId).whenever(keyManager).generatePrivateKey(Jwa.ES256K)
+    doReturn(nextUpdateKeyId).whenever(keyManager).generatePrivateKey(AlgorithmId.secp256k1)
 
     val service: Service = mapper.readValue(File("src/test/resources/service1.json").readText())
     val publicKey1 = publicKey1VerificationMethod(mapper)
@@ -450,7 +450,7 @@ class DidIonTest {
     val nextUpdateKey = readKey("src/test/resources/jwkEs256k3Public.json")
     val nextUpdateKeyId = keyManager.import(nextUpdateKey)
 
-    doReturn(nextRecoveryKeyId, nextUpdateKeyId).whenever(keyManager).generatePrivateKey(Jwa.ES256K)
+    doReturn(nextRecoveryKeyId, nextUpdateKeyId).whenever(keyManager).generatePrivateKey(AlgorithmId.secp256k1)
 
     val (recoverOperation, keyAliases) = DidIon.createRecoverOperation(
       keyManager,

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
+import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Jwa
 import web5.sdk.dids.DidResolutionResult
@@ -79,7 +80,7 @@ class DidJwkTest {
     @Test
     fun `private key throws exception`() {
       val manager = InMemoryKeyManager()
-      manager.generatePrivateKey(Jwa.ES256K)
+      manager.generatePrivateKey(AlgorithmId.secp256k1)
       val privateJwk = JWK.parse(manager.export().first())
       val encodedPrivateJwk = Convert(privateJwk.toJSONString()).toBase64Url(padding = false)
 

--- a/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
+++ b/dids/src/test/kotlin/web5/sdk/dids/methods/jwk/DidJwkTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import web5.sdk.common.Convert
 import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.crypto.Jwa
 import web5.sdk.dids.DidResolutionResult
 import web5.sdk.dids.DidResolvers
 import web5.sdk.testing.TestVectors
@@ -78,7 +79,7 @@ class DidJwkTest {
     @Test
     fun `private key throws exception`() {
       val manager = InMemoryKeyManager()
-      manager.generatePrivateKey(JWSAlgorithm.ES256K)
+      manager.generatePrivateKey(Jwa.ES256K)
       val privateJwk = JWK.parse(manager.export().first())
       val encodedPrivateJwk = Convert(privateJwk.toJSONString()).toBase64Url(padding = false)
 


### PR DESCRIPTION
# Overview
Eliminating use of `Curve` and `Algorithm` from `nimbusds` dependency and instead using our own enums `JwaCurve` and `Jwa`, respectively. Adopting use of `AlgorithmId` which is a combination of `JwaCurve` and `Jwa`. 

This PR is the first step to remove dependency on the nimbusds library and preventing exposing their types through our public API surface.

# Description
## Impact
- Changes to many method signatures in crypto and dids package. Mostly requiring passing in of `AlgorithmId` instead of nimbus Algorithm and nimbus Curve.
## Follow up tasks
- Roll our own enums for JWK as well as various nimbus methods we still use internally, and completely remove nimbusds dependency 

# How Has This Been Tested?
- Unit tests have been fixed to align with the new public API surface. No implementation change happened. 

# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages

## References
[JWA spec](https://datatracker.ietf.org/doc/html/rfc7518)
