### PR TITLE
Suite of Security Vulnerability Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ versions in `gradle/libs.versions.toml` and import references defined
 there in the subproject `build.gradle.kts` files. More docs on this 
 approach using Gradle Version Catalogs is at the top of `gradle/libs.versions.toml`.
 
+We have a secondary mechanism to force dependency upgrades of transitive
+deps in the case we encounter security vulnerabilities we do not directly
+depend upon. That config is located in the `resolutionStrategy` section of 
+`./build.gradle.kts`. Notes for applying fixes for security vulnerabilities
+are documented there.
+
 ## Prerequisites
 
 Install java version 11. If you're installing a higher version, it must be compatible with Gradle 8.2.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ allprojects {
     resolutionStrategy {
       // Pin the transitive dep to a version that's not vulnerable.
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+      // Addresss https://github.com/TBD54566975/web5-kt/issues/242
+      force("com.google.protobuf:protobuf-javalite:3.19.6")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,27 @@ plugins {
 
 allprojects {
   configurations.all {
+    /**
+     * In this section we address build issues including security vulnerabilities
+     * in transitive dependencies we don't explicitly declare in
+     * `gradle/libs.versions.toml`. Forced actions taken here will override any
+     * declarations we make, so use with care. Also note: these are in place for a
+     * point in time. As we maintain this software, the manual forced resolution we do
+     * here may:
+     *
+     * 1) No longer be necessary (if we have removed a dependency path leading to dep)
+     * 2) Break an upgrade (if we upgrade a dependency and this forces a lower version
+     *    of a transitive dependency it brings in)
+     *
+     * So we need to exercise care here, and, when upgrading our deps, check to see if
+     * these forces aren't breaking things.
+     *
+     * When adding forces here, please reference the issue which explains why we
+     * needed to do this; it will help future maintainers understand if the force
+     * is still valid, should be removed, or handled in another way.
+     *
+     * When in doubt, ask! :)
+     */
     resolutionStrategy {
       // Pin the transitive dep to a version that's not vulnerable.
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,10 +18,12 @@ plugins {
   id("version-catalog")
 }
 
-configurations.all {
-  resolutionStrategy {
-    // Pin the transitive dep to a version that's not vulnerable.
-    force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+allprojects {
+  configurations.all {
+    resolutionStrategy {
+      // Pin the transitive dep to a version that's not vulnerable.
+      force("com.fasterxml.woodstox:woodstox-core:6.4.0")
+    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ allprojects {
       force("com.google.protobuf:protobuf-javalite:3.19.6")
       // Addresss https://github.com/TBD54566975/web5-kt/issues/243
       force("com.google.guava:guava:32.0.0-android")
+      // Addresses https://github.com/TBD54566975/web5-kt/issues/244
+      force("com.squareup.okio:okio:3.6.0")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ allprojects {
       force("com.fasterxml.woodstox:woodstox-core:6.4.0")
       // Addresss https://github.com/TBD54566975/web5-kt/issues/242
       force("com.google.protobuf:protobuf-javalite:3.19.6")
+      // Addresss https://github.com/TBD54566975/web5-kt/issues/243
+      force("com.google.guava:guava:32.0.0-android")
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@
 # up the same version. This will guarantee that submodule test suites are running
 # in the correct ClassLoading environment aligned with the Web5 platform.
 #
+# WARNING: The manual "force" clauses in "./build.gradle.kts" will override
+# anything we declare here. If you're wondering why dependencies (and transitive deps)
+# aren't resolving as declared here, check there.
+#
 # More about Gradle Version Catalogs:
 # https://docs.gradle.org/current/userguide/platforms.html
 #


### PR DESCRIPTION
A series of commits to address security vulns in the `web5-kt` projects. Grouped as one PR so they may be tested together to clear FOSSA security scanning to  ✅. 

On `main`, 5 security issues on FOSSA:
<img width="544" alt="image" src="https://github.com/TBD54566975/web5-kt/assets/199891/ad5d05a7-ef8d-4246-86a9-6d1e10e11054">

In this PR, 0 security issues on FOSSA:
<img width="849" alt="image" src="https://github.com/TBD54566975/web5-kt/assets/199891/bc0d14af-c556-4812-8544-ba8076be3126">

Recommended merge approach when approved: Rebase, do not squash and merge. This will preserve optionality for us to individually `git blame` and do reverts if necessary.

This PR resolves #240, #242, #243, #244, and adds documentation.