### PR TITLE
FIX: `did:dht` resolution

### DIFF
--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -559,7 +559,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
                 .build()
             }
             // handle type indexing
-            name == "_typ._did." -> {
+            name.startsWith("_typ._did.") -> {
               if (rr.strings[0].isNotEmpty() && rr.strings.size == 1) {
                 types += rr.strings[0].removePrefix("id=").split(ARRAY_SEPARATOR).map {
                   DidDhtTypeIndexing.fromInt(it.toInt()) ?: throw IllegalArgumentException("invalid type index")
@@ -569,15 +569,15 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) : DidMethod<Di
               }
             }
             // handle root record
-            name == "_did." -> {
+            name.startsWith("_did.") -> {
               handleRootRecord(rr, keyLookup, doc)
             }
             // handle controller record
-            name == "_cnt._did." -> {
+            name.startsWith("_cnt._did.") -> {
               handleControllerRecord(rr, doc)
             }
             // handle alsoKnownAs record
-            name == "_aka._did." -> {
+            name.startsWith("_aka._did.") -> {
               handleAlsoKnownAsRecord(rr, doc)
             }
           }


### PR DESCRIPTION
# Overview
fixed `did:dht` resolution.

# Description
There was a recent change to `did:dht` TXT record names that requires the method specific id to be included as the last part of each TXT record

![image](https://github.com/TBD54566975/web5-kt/assets/4887440/00b1e9a0-6817-45e4-adc8-6f5323d494c8)

`main` is currently looking for several records using strict equality. example [here](https://github.com/TBD54566975/web5-kt/blob/main/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt#L572). 

This PR changes strict equality checks to prefix checks. We would have had to make this change for the root record anyway because of the possibility for `_did.TLD`


> [!WARNING]
> I'll fix create and update in a subsequent PR. want to get this one out to unblock others
