### PR TITLE
Add Evidence

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -152,7 +152,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
         .apply {
           evidence?.let {
             properties(
-              mutableMapOf(
+              mapOf(
                 "evidence" to evidence
               ) as Map<String, Any>?
             )

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -44,6 +44,8 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
 
   public val subject: String
     get() = vcDataModel.credentialSubject.id.toString()
+  public val evidence: List<Any>?
+    get() = vcDataModel.toMap().get("evidence") as List<Any>?
 
   /**
    * Sign a verifiable credential using a specified decentralized identifier ([did]) with the private key that pairs
@@ -106,9 +108,10 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
      * @param type The type of the credential, as a [String].
      * @param issuer The issuer URI of the credential, as a [String].
      * @param subject The subject URI of the credential, as a [String].
+     * @param data The credential data, as a generic type [T].
      * @param issuanceDate Optional date to set in the `issuanceDate` property of the credential.
      * @param expirationDate Optional date to set in the `expirationDate` property of the credential.
-     * @param data The credential data, as a generic type [T].
+     * @param evidence Optional evidence property that gives additional supporting data
      * @return A [VerifiableCredential] instance.
      *
      * Example:
@@ -124,7 +127,8 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
       data: T,
       credentialStatus: CredentialStatus? = null,
       issuanceDate: Date = Date(),
-      expirationDate: Date? = null
+      expirationDate: Date? = null,
+      evidence: List<Any>? = null
     ): VerifiableCredential {
 
       val jsonData: JsonNode = objectMapper.valueToTree(data)
@@ -143,8 +147,17 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
         .id(URI.create("urn:uuid:${UUID.randomUUID()}"))
         .issuer(URI.create(issuer))
         .issuanceDate(issuanceDate)
-        .apply { expirationDate?.let { expirationDate(it) } }
         .credentialSubject(credentialSubject)
+        .apply { expirationDate?.let { expirationDate(it) } }
+        .apply {
+          evidence?.let {
+            properties(
+              mutableMapOf(
+                "evidence" to evidence
+              ) as Map<String, Any>?
+            )
+          }
+        }
         .apply {
           credentialStatus?.let {
             credentialStatus(it)

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -115,6 +115,40 @@ class VerifiableCredentialTest {
     VerifiableCredential.verify(vcJwt)
   }
 
+  @Test
+  fun `verify does not throw an exception with vc with evidence`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidJwk.create(keyManager)
+    val holderDid = DidJwk.create(keyManager)
+
+    val evidence = listOf(
+      mapOf(
+        "id" to "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
+        "type" to listOf("DocumentVerification"),
+        "verifier" to "https://example.edu/issuers/14",
+        "evidenceDocument" to "DriversLicense",
+        "subjectPresence" to "Physical",
+        "documentPresence" to "Physical",
+        "licenseNumber" to "123AB4567"
+      )
+    )
+
+    val vc = VerifiableCredential.create(
+      type = "StreetCred",
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true),
+      evidence = evidence
+    )
+
+    assertEquals(vc.evidence, evidence)
+    val vcJwt = vc.sign(issuerDid)
+    VerifiableCredential.verify(vcJwt)
+
+    val parsedVc = VerifiableCredential.parseJwt(vcJwt)
+    assertEquals(parsedVc.evidence, evidence)
+  }
+
 
   data class KnowYourCustomerCred(val country: String)
   @Test


### PR DESCRIPTION
# Overview
Add Evidence to our vc data model

# Description
Adding optional evidence field to creation of the vc data model

Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential. This could be used by the verifier to establish the confidence with which it relies on the claims in the verifiable credential.

https://www.w3.org/TR/vc-data-model/#evidence

