### PR TITLE
Fix latest releases

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,9 +1,13 @@
 name: Deploy examples to GitHub Pages
 
 on:
+  # Runs on new releases publishing
   push:
-    branches:
-      - main
+    tags:
+      - v**
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build-web5-sdk-kotlin:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           tag_name: v${{ github.event.inputs.version }}
           draft: false
-          prerelease: true
+          prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
The new releases are not being updated as latest because of the `prerelease` tag. This PR fixes it. 

Also fixes #265 