### PR TITLE
Make VC Verify more robust

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -11,11 +11,12 @@ import com.fasterxml.jackson.module.kotlin.convertValue
 import com.nfeld.jsonpathkt.JsonPath
 import com.nfeld.jsonpathkt.extension.read
 import web5.sdk.common.Json
+import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.did.BearerDid
+import web5.sdk.dids.methods.dht.DidDht
 import web5.sdk.jose.jwt.Jwt
 import web5.sdk.jose.jwt.JwtClaimsSet
 import java.net.URI
-import java.security.SignatureException
 import java.util.Date
 import java.util.UUID
 
@@ -204,46 +205,54 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
       val decodedJwt = Jwt.decode(vcJwt)
 
       val exp = decodedJwt.claims.exp
-      val iss =  decodedJwt.claims.iss
-      val nbf =  decodedJwt.claims.nbf
-      val jti =  decodedJwt.claims.jti
-      val sub =  decodedJwt.claims.sub
+      val iss = decodedJwt.claims.iss
+      val nbf = decodedJwt.claims.nbf
+      val jti = decodedJwt.claims.jti
+      val sub = decodedJwt.claims.sub
       val vc = parseJwt(vcJwt)
-      val vcTyped = vc.vcDataModel
+      val vcDataModel = vc.vcDataModel
 
       // exp MUST represent the expirationDate property, encoded as a UNIX timestamp (NumericDate).
-      require(exp == null || vcTyped.expirationDate == null || exp == vcTyped.expirationDate.time / 1000) {
-        "Verification failed: exp claim does not match expirationDate"
+      // IF exp is present, check that vc's exp date is same as the jwt's exp date
+      if (
+        exp != null &&
+        vcDataModel.expirationDate != null &&
+        exp != vcDataModel.expirationDate.time / 1000
+      ) {
+        throw IllegalArgumentException("Verification failed: exp claim does not match expirationDate")
       }
 
       require(iss != null) { "Verification failed: iss claim is required" }
 
-      // iss MUST represent the issuer property of a verifiable credential or the holder property of a verifiable presentation.
-      require(iss == vcTyped.issuer.toString()) {
+      // if iss is present, iss MUST represent the issuer property of a vc or the holder property of a vp.
+      require(iss == vcDataModel.issuer.toString()) {
         "Verification failed: iss claim does not match expected issuer"
       }
 
-      // nbf cannot represent time in the future
-      require(nbf == null || nbf <= Date().time / 1000) {
-        "Verification failed: nbf claim is in the future"
+      // if nbf is present, nbf cannot represent time in the future
+      if (nbf != null && nbf >= Date().time / 1000) {
+        throw IllegalArgumentException("Verification failed: nbf claim is in the future")
       }
 
-      // nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).
-      require(nbf == null || vcTyped.issuanceDate == null || nbf == vcTyped.issuanceDate.time / 1000) {
-        "Verification failed: nbf claim does not match issuanceDate"
+      // if nbf is present, nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).
+      if (
+        nbf != null &&
+        vcDataModel.issuanceDate != null &&
+        nbf != vcDataModel.issuanceDate.time / 1000) {
+        throw IllegalArgumentException("Verification failed: nbf claim does not match issuanceDate")
       }
 
-      // sub MUST represent the id property contained in the credentialSubject.
-      require(sub == null || sub == vcTyped.credentialSubject.id.toString()) {
-        "Verification failed: sub claim does not match credentialSubject.id"
+      // if sub is present, sub MUST represent the id property contained in the credentialSubject.
+      if (sub != null && sub != vcDataModel.credentialSubject.id.toString()) {
+        throw IllegalArgumentException("Verification failed: sub claim does not match credentialSubject.id")
       }
 
-      // jti MUST represent the id property of the verifiable credential or verifiable presentation.
-      require(jti == null || jti == vcTyped.id.toString()) {
-        "Verification failed: jti claim does not match id"
+      // if jti is present, jti MUST represent the id property of the verifiable credential or verifiable presentation.
+      if (jti != null && jti != vcDataModel.id.toString()) {
+        throw IllegalArgumentException("Verification failed: jti claim does not match id")
       }
 
-      validateDataModel(vcTyped.toMap())
+      validateDataModel(vcDataModel.toMap())
       decodedJwt.verify()
     }
 
@@ -261,8 +270,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
     public fun parseJwt(vcJwt: String): VerifiableCredential {
       val jwt = Jwt.decode(vcJwt)
       val jwtPayload = jwt.claims
-      val vcDataModelValue = jwtPayload.misc["vc"] ?:
-        throw IllegalArgumentException("jwt payload missing vc property")
+      val vcDataModelValue = jwtPayload.misc["vc"] ?: throw IllegalArgumentException("jwt payload missing vc property")
 
       val vcDataModelMap = Json.parse<Map<String, Any>>(Json.stringify(vcDataModelValue))
 

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -229,7 +229,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
       }
 
       // sub MUST represent the id property contained in the credentialSubject.
-      require(sub == null || vcTyped.credentialSubject is List<*> || sub == vcTyped.credentialSubject.id.toString()) {
+      require(sub == null || sub == vcTyped.credentialSubject.id.toString()) {
         "Verification failed: sub claim does not match credentialSubject.id"
       }
 

--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -175,9 +175,14 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
     /**
      * Verifies the integrity and authenticity of a Verifiable Credential (VC) encoded as a JSON Web Token (JWT).
      *
-     * If any of these steps fail, the function will throw a [IllegalArgumentException] with a message indicating the nature of the failure:
+     * This method conforms to wording about VC data model JWT encoding
+     * https://www.w3.org/TR/vc-data-model/#jwt-encoding
+     *
+     * If any of these steps fail, the function will throw a [IllegalArgumentException]
+     * with a message indicating the nature of the failure:
      * - exp MUST represent the expirationDate property, encoded as a UNIX timestamp (NumericDate).
-     * - iss MUST represent the issuer property of a verifiable credential or the holder property of a verifiable presentation.
+     * - iss MUST represent the issuer property of a verifiable credential or the holder property
+     *   of a verifiable presentation.
      * - nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).
      * - jti MUST represent the id property of the verifiable credential or verifiable presentation.
      * - sub MUST represent the id property contained in the credentialSubject.

--- a/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/PresentationExchangeTest.kt
@@ -664,13 +664,13 @@ class Web5TestVectorsPresentationExchange {
     val testVectors =
       mapper.readValue(File("../web5-spec/test-vectors/presentation_exchange/validate_definition.json"), typeRef)
 
-    testVectors.vectors.filterNot { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
       assertDoesNotThrow {
         PresentationExchange.validateDefinition(vector.input.presentationDefinition)
       }
     }
 
-    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
       assertFails {
           PresentationExchange.validateDefinition(vector.input.presentationDefinition)
       }
@@ -687,13 +687,13 @@ class Web5TestVectorsPresentationExchange {
     val testVectors =
       mapper.readValue(File("../web5-spec/test-vectors/presentation_exchange/validate_submission.json"), typeRef)
 
-    testVectors.vectors.filterNot { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
       assertDoesNotThrow {
         PresentationExchange.validateSubmission(vector.input.presentationSubmission)
       }
     }
 
-    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
       assertFails {
         PresentationExchange.validateSubmission(vector.input.presentationSubmission)
       }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -12,10 +12,8 @@ import web5.sdk.crypto.AlgorithmId
 import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Jwa
-import web5.sdk.crypto.jwk.Jwk
 import web5.sdk.dids.did.BearerDid
 import web5.sdk.dids.did.PortableDid
-import web5.sdk.dids.didcore.DidDocument
 import web5.sdk.dids.didcore.Purpose
 import web5.sdk.jose.jws.JwsHeader
 import web5.sdk.jose.jwt.Jwt
@@ -28,7 +26,6 @@ import web5.sdk.testing.TestVectors
 import java.io.File
 import java.security.SignatureException
 import java.util.Calendar
-import java.util.Date
 import kotlin.test.Ignore
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -359,7 +356,7 @@ class Web5TestVectorsCredentials {
   }
 
   @Test
-  fun verifyVcwt() {
+  fun verifyVcJwt() {
     val typeRef = object : TypeReference<TestVectors<String, Unit>>() {}
     val testVectors = mapper.readValue(File("../web5-spec/test-vectors/vc_jwt/verify.json"), typeRef)
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -345,25 +345,15 @@ class Web5TestVectorsCredentials {
     val typeRef = object : TypeReference<TestVectors<VerifyTestInput, Unit>>() {}
     val testVectors = mapper.readValue(File("../web5-spec/test-vectors/credentials/verify.json"), typeRef)
 
-    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
+    testVectors.vectors.filterNot { it.errors ?: false }.forEach { vector ->
       assertDoesNotThrow {
         VerifiableCredential.verify(vector.input.vcJwt)
       }
     }
 
-    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
-      val result = runCatching {
+    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+      assertFails {
         VerifiableCredential.verify(vector.input.vcJwt)
-      }
-
-      assert(result.isFailure) { "Test Vector was expected to fail for vector: ${vector.description}" }
-
-      if(vector.errorMessage != null && vector.errorMessage!!["web5-kt"] != null) {
-        val expectedErrorMessage = vector.errorMessage!!["web5-kt"]
-        val actualErrorMessage = result.exceptionOrNull()?.message
-
-        assertEquals(expectedErrorMessage, actualErrorMessage,
-          "Expected and actual error messages do not match for vector: ${vector.description}")
       }
     }
   }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -27,6 +27,7 @@ import web5.sdk.dids.methods.key.DidKey
 import web5.sdk.testing.TestVectors
 import java.io.File
 import java.security.SignatureException
+import java.util.Calendar
 import java.util.Date
 import kotlin.test.Ignore
 import kotlin.test.assertContains
@@ -180,7 +181,7 @@ class VerifiableCredentialTest {
       type = "KnowYourCustomerCred",
       issuer = issuerDid.uri,
       subject = subjectDid.uri,
-      expirationDate = Date(2055,11,21),
+      expirationDate = Calendar.Builder().setDate(2055, 11, 21).build().time,
       data = KnowYourCustomerCred(country = "us")
     )
 
@@ -344,13 +345,13 @@ class Web5TestVectorsCredentials {
     val typeRef = object : TypeReference<TestVectors<VerifyTestInput, Unit>>() {}
     val testVectors = mapper.readValue(File("../web5-spec/test-vectors/credentials/verify.json"), typeRef)
 
-    testVectors.vectors.filterNot { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
       assertDoesNotThrow {
         VerifiableCredential.verify(vector.input.vcJwt)
       }
     }
 
-    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
       val result = runCatching {
         VerifiableCredential.verify(vector.input.vcJwt)
       }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -350,18 +350,14 @@ class Web5TestVectorsCredentials {
       }
     }
 
-    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
-      if(vector.errorMessage == null || vector.errorMessage!!["web5-kt"] == null) {
-        assertFails(vector.description) {
-          VerifiableCredential.verify(vector.input.vcJwt)
-        }
-      } else {
-        val result = runCatching {
-          VerifiableCredential.verify(vector.input.vcJwt)
-        }
+    testVectors.vectors.filter { it.errors ?: false }.forEach { vector ->
+      val result = runCatching {
+        VerifiableCredential.verify(vector.input.vcJwt)
+      }
 
-        assert(result.isFailure) { "Test Vector was expected to fail for vector: ${vector.description}" }
+      assert(result.isFailure) { "Test Vector was expected to fail for vector: ${vector.description}" }
 
+      if(vector.errorMessage != null && vector.errorMessage!!["web5-kt"] != null) {
         val expectedErrorMessage = vector.errorMessage!!["web5-kt"]
         val actualErrorMessage = result.exceptionOrNull()?.message
 

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -357,4 +357,22 @@ class Web5TestVectorsCredentials {
       }
     }
   }
+
+  @Test
+  fun verifyVcwt() {
+    val typeRef = object : TypeReference<TestVectors<String, Unit>>() {}
+    val testVectors = mapper.readValue(File("../web5-spec/test-vectors/vc_jwt/verify.json"), typeRef)
+
+    testVectors.vectors.filter { it.errors == false }.forEach { vector ->
+      assertDoesNotThrow {
+        VerifiableCredential.verify(vector.input)
+      }
+    }
+
+    testVectors.vectors.filter { it.errors == true }.forEach { vector ->
+      assertFails {
+        VerifiableCredential.verify(vector.input)
+      }
+    }
+  }
 }

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -129,30 +129,12 @@ class VerifiableCredentialTest {
     )
 
     val vcJwt = vc.sign(issuerDid)
-//    VerifiableCredential.verify(vcJwt)
+
     assertFails("should fail with fake issuer") {
-//          VerifiableCredential.fromJson(mapper.writeValueAsString(vector.input.credential))
       VerifiableCredential.verify(vcJwt)
     }
   }
-//  it('should throw and error if wrong issuer', async () => {
-//    const issuerDid = await DidKey.create();
-//    const vc = await VerifiableCredential.create({
-//      type    : 'StreetCred',
-//      issuer  : 'did:fakeissuer:123',
-//      subject : 'did:subject:123',
-//      data    : new StreetCredibility('high', true),
-//    });
-//
-//    const vcJwt = await vc.sign({ did: issuerDid });
-//
-//    try {
-//      await VerifiableCredential.verify({ vcJwt });
-//      expect.fail();
-//    } catch(e: any) {
-//      expect(e.message).to.include('Verification failed: iss claim does not match expected issuer');
-//    }
-//  });
+
   @Test
   fun `verify does not throw an exception with vc with evidence`() {
     val keyManager = InMemoryKeyManager()
@@ -186,7 +168,6 @@ class VerifiableCredentialTest {
     val parsedVc = VerifiableCredential.parseJwt(vcJwt)
     assertEquals(parsedVc.evidence, evidence)
   }
-
 
   data class KnowYourCustomerCred(val country: String)
   @Test
@@ -347,7 +328,7 @@ class Web5TestVectorsCredentials {
       val keyManager = InMemoryKeyManager()
       val bearerDid = BearerDid.import(portableDid, keyManager)
       val vcJwt = vc.sign(bearerDid)
-      
+
       assertEquals(vector.output, vcJwt, vector.description)
     }
 

--- a/jose/src/main/kotlin/web5/sdk/jose/jws/Jws.kt
+++ b/jose/src/main/kotlin/web5/sdk/jose/jws/Jws.kt
@@ -244,6 +244,12 @@ public class DecodedJws(
 
   /**
    * Verify the JWS signature is valid.
+   *
+   * - Ensures the presence of critical header elements `alg` and `kid` in the JWT header.
+   * - Resolves the Decentralized Identifier (DID) and retrieves the associated DID Document.
+   * - Validates the DID and establishes a set of valid verification method IDs.
+   * - Identifies the correct Verification Method from the DID Document based on the `kid` parameter.
+   * - Verifies the JWT's signature using the public key associated with the Verification Method.
    */
   public fun verify() {
     check(header.kid != null || header.alg != null) {

--- a/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
+++ b/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
@@ -19,5 +19,5 @@ public class TestVector<I,O>(
   public val description: String,
   public val input: I,
   public val output: O?,
-  public val errors: Boolean? = false
+  public val errors: Boolean? = false,
 )

--- a/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
+++ b/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
@@ -20,4 +20,5 @@ public class TestVector<I,O>(
   public val input: I,
   public val output: O?,
   public val errors: Boolean? = false,
+  public val errorMessage: Map<String, String>? = null
 )

--- a/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
+++ b/testing/src/main/kotlin/web5/sdk/testing/TestVectors.kt
@@ -19,6 +19,5 @@ public class TestVector<I,O>(
   public val description: String,
   public val input: I,
   public val output: O?,
-  public val errors: Boolean? = false,
-  public val errorMessage: Map<String, String>? = null
+  public val errors: Boolean? = false
 )


### PR DESCRIPTION
# Overview
Added vcJwt checks to verify

# Description
     * If any of these steps fail, the function will throw a [IllegalArgumentException] with a message indicating the nature of the failure:
     * - exp MUST represent the expirationDate property, encoded as a UNIX timestamp (NumericDate).
     * - iss MUST represent the issuer property of a verifiable credential or the holder property of a verifiable presentation.
     * - nbf MUST represent issuanceDate, encoded as a UNIX timestamp (NumericDate).
     * - jti MUST represent the id property of the verifiable credential or verifiable presentation.
     * - sub MUST represent the id property contained in the credentialSubject.

# How Has This Been Tested?
Added new vector - https://github.com/TBD54566975/web5-spec/pull/146
