### PR TITLE
Fix artifactory SNAPSHOT publishing w/o credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,15 @@ jobs:
             --batch-mode \
             -DnewVersion=${{ steps.resolve_version.outputs.resolved_version }}
 
-          # Maven deploy lifecycle will build, run tests, verify, sign, and deploy
-          mvn \
-            deploy \
-              --batch-mode \
-              --settings .maven_settings.xml \
-              -P sign-artifacts
+          # Only attempt to publish artifact if we have credentials
+          if [ -n "${{ secrets.ARTIFACTORY_PASSWORD }}" ]; then
+            # Maven deploy lifecycle will build, run tests, verify, sign, and deploy
+            mvn deploy --batch-mode --settings .maven_settings.xml -P sign-artifacts
+          else
+            # Otherwise, Maven verify lifecycle will build, run tests, and verify
+            mvn verify --batch-mode
+          fi
+
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}


### PR DESCRIPTION
Fix build failures due to PRs from external contributors (or bots) which won't have access to artifactory publishing

Example: https://github.com/TBD54566975/web5-kt/actions/runs/9086925778/job/25066223935
> Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project web5: Failed to deploy artifacts: Could not transfer artifact xyz.block:web5-parent:pom:commit-02d5da2-20240516.174542-1 from/to tbd-oss-snapshots (https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-maven2): status code: 401, reason phrase:  (401) -> [Help 1]