### PR TITLE
making vc type nullable during VerifiableCredential.Create()

### DIFF
--- a/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
+++ b/credentials/src/main/kotlin/web5/sdk/credentials/VerifiableCredential.kt
@@ -131,7 +131,7 @@ public class VerifiableCredential internal constructor(public val vcDataModel: V
      */
     @JvmOverloads
     public fun <T> create(
-      type: String,
+      type: String? = null,
       issuer: String,
       subject: String,
       data: T,

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -342,6 +342,9 @@ fun `kyc credential verify does not throw an exception if vc is legit`() {
       data = StreetCredibility(localRespect = "high", legit = true)
     )
 
+    val vcDataModelType = vc.vcDataModel.jsonObject["type"] as List<*>
+    assertEquals(vcDataModelType.size, 1)
+
     assertEquals(vc.type, "VerifiableCredential")
     assertEquals(vc.issuer, issuerDid.uri)
     assertEquals(vc.subject, holderDid.uri)

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 data class StreetCredibility(val localRespect: String, val legit: Boolean)
 class VerifiableCredentialTest {
@@ -327,6 +328,23 @@ fun `kyc credential verify does not throw an exception if vc is legit`() {
     assertEquals(vc.type, parsedVc.type)
     assertEquals(vc.issuer, parsedVc.issuer)
     assertEquals(vc.subject, parsedVc.subject)
+  }
+
+  @Test
+  fun `create can create a VC with default VerifiableCredential type with null type passed in`() {
+    val keyManager = InMemoryKeyManager()
+    val issuerDid = DidKey.create(keyManager)
+    val holderDid = DidKey.create(keyManager)
+
+    val vc = VerifiableCredential.create(
+      issuer = issuerDid.uri,
+      subject = holderDid.uri,
+      data = StreetCredibility(localRespect = "high", legit = true)
+    )
+
+    assertEquals(vc.type, "VerifiableCredential")
+    assertEquals(vc.issuer, issuerDid.uri)
+    assertEquals(vc.subject, holderDid.uri)
   }
 }
 


### PR DESCRIPTION
# Overview
closes #320 

# Description
made `type` nullable when creating a vc via `VerifiableCredential.create()`

# How Has This Been Tested?
i wrote a test that makes sure the vc created with `null` type still has the default type of `VerifiableCredential` and the vcDataModel's `type` array has 1 item `["VerifiableCredential"]`

