### PR TITLE
Issue #322: Move AwsKeyManager to its own module

### DIFF
--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -108,6 +108,12 @@
       if desired.
     -->
     <dependency>
+      <groupId>xyz.block</groupId>
+      <artifactId>web5-keymanager-aws</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.ktor</groupId>
       <artifactId>ktor-client-mock-jvm</artifactId>
     </dependency>

--- a/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
+++ b/credentials/src/test/kotlin/web5/sdk/credentials/VerifiableCredentialTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import web5.sdk.common.Convert
 import web5.sdk.common.Json
 import web5.sdk.crypto.AlgorithmId
-import web5.sdk.crypto.AwsKeyManager
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.crypto.Jwa
 import web5.sdk.dids.did.BearerDid
@@ -18,13 +17,13 @@ import web5.sdk.dids.didcore.Purpose
 import web5.sdk.jose.jws.JwsHeader
 import web5.sdk.jose.jwt.Jwt
 import web5.sdk.jose.jwt.JwtClaimsSet
+import web5.sdk.keymanager.aws.AwsKeyManager
 import web5.sdk.dids.methods.dht.CreateDidDhtOptions
 import web5.sdk.dids.methods.dht.DidDht
 import web5.sdk.dids.methods.jwk.DidJwk
 import web5.sdk.dids.methods.key.DidKey
 import web5.sdk.testing.TestVectors
 import java.io.File
-import java.net.URI
 import java.security.SignatureException
 import java.util.Calendar
 import kotlin.test.Ignore
@@ -32,7 +31,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 data class StreetCredibility(val localRespect: String, val legit: Boolean)
 class VerifiableCredentialTest {

--- a/dids/pom.xml
+++ b/dids/pom.xml
@@ -91,6 +91,10 @@
       <groupId>io.ktor</groupId>
       <artifactId>ktor-serialization-jackson-jvm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
 
     <!--
       Test dependencies may declare direct versions; they are not exported
@@ -100,7 +104,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.16.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -55,11 +55,6 @@
       <artifactId>web5-jose</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>xyz.block</groupId>
-      <artifactId>web5-keymanager-aws</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- External -->
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>web5-jose</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>xyz.block</groupId>
+      <artifactId>web5-keymanager-aws</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- External -->
 

--- a/keymanager-aws/pom.xml
+++ b/keymanager-aws/pom.xml
@@ -13,9 +13,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <!-- Artifact Configuration -->
-  <artifactId>web5-crypto</artifactId>
-  <name>Web5 Crypto</name>
-  <description>Crypto libraries for Web5</description>
+  <artifactId>web5-keymanager-aws</artifactId>
+  <name>Web5 AWS KeyManager Implementation</name>
+  <description>AWS Implementation of KeyManager</description>
 
 
   <!-- Properties -->
@@ -31,7 +31,7 @@
     <!-- Internal Dependencies -->
     <dependency>
       <groupId>xyz.block</groupId>
-      <artifactId>web5-common</artifactId>
+      <artifactId>web5-crypto</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -43,31 +43,8 @@
 
     <!-- External -->
     <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-kotlin</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.crypto.tink</groupId>
-      <artifactId>tink</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15to18</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15to18</artifactId>
-    </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <scope>test</scope>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-kms</artifactId>
     </dependency>
 
   </dependencies>

--- a/keymanager-aws/pom.xml
+++ b/keymanager-aws/pom.xml
@@ -52,5 +52,26 @@
   <!-- Build Configuration -->
   <build>
 
+    <pluginManagement>
+      <plugins>
+
+        <!--
+
+        Remove this section when
+        https://github.com/TBD54566975/web5-kt/issues/328
+        is complete.
+
+        -->
+        <plugin>
+          <groupId>io.github.martinvisser</groupId>
+          <artifactId>kover-maven-plugin</artifactId>
+          <configuration>
+            <!-- We temporarily disable coverage enforcement until we have tests working for this module -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
   </build>
 </project>

--- a/keymanager-aws/src/main/kotlin/web5/sdk/keymanager/aws/AwsKeyManager.kt
+++ b/keymanager-aws/src/main/kotlin/web5/sdk/keymanager/aws/AwsKeyManager.kt
@@ -1,4 +1,4 @@
-package web5.sdk.crypto
+package web5.sdk.keymanager.aws
 
 import com.amazonaws.services.kms.AWSKMS
 import com.amazonaws.services.kms.AWSKMSClientBuilder
@@ -19,6 +19,11 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.crypto.ExtendedDigest
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
+import web5.sdk.crypto.AlgorithmId
+import web5.sdk.crypto.Jwa
+import web5.sdk.crypto.JwaCurve
+import web5.sdk.crypto.KeyGenOptions
+import web5.sdk.crypto.KeyManager
 import web5.sdk.crypto.jwk.Jwk
 import java.nio.ByteBuffer
 import java.security.PublicKey

--- a/keymanager-aws/src/test/kotlin/web5/sdk/keymanager/aws/AwsKeyManagerTest.kt
+++ b/keymanager-aws/src/test/kotlin/web5/sdk/keymanager/aws/AwsKeyManagerTest.kt
@@ -1,4 +1,4 @@
-package web5.sdk.crypto
+package web5.sdk.keymanager.aws
 
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.auth.AWSStaticCredentialsProvider
@@ -7,6 +7,9 @@ import com.amazonaws.services.kms.AWSKMSClient
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import web5.sdk.crypto.AlgorithmId
+import web5.sdk.crypto.Crypto
+import web5.sdk.crypto.Jwa
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -45,11 +48,11 @@ class AwsKeyManagerTest {
     val signature = awsKeyManager.sign(alias, signingInput)
 
     //Verify the signature with BouncyCastle via Crypto
-    Crypto.verify(
-      publicKey = awsKeyManager.getPublicKey(alias),
-      signedPayload = signingInput,
-      signature = signature
-    )
+      Crypto.verify(
+          publicKey = awsKeyManager.getPublicKey(alias),
+          signedPayload = signingInput,
+          signature = signature
+      )
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <module>dids</module>
     <module>distribution</module>
     <module>jose</module>
+    <module>keymanager-aws</module>
     <module>testing</module>
   </modules>
 
@@ -103,10 +104,12 @@
     <version.com.networknt>1.0.87</version.com.networknt>
     <version.com.nfeld.jsonpathkt>2.0.1</version.com.nfeld.jsonpathkt>
     <version.com.squareup.okhttp3>4.12.0</version.com.squareup.okhttp3>
+    <version.commons.codec>1.17.0</version.commons.codec>
     <version.dnsjava>3.5.2</version.dnsjava>
     <version.io.github.erdtman>1.1</version.io.github.erdtman>
     <version.io.github.oshai>6.0.2</version.io.github.oshai>
     <version.io.ktor>2.3.7</version.io.ktor>
+    <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
     <version.org.bouncycastle>1.78</version.org.bouncycastle>
     <version.org.junit.jupiter>5.10.1</version.org.junit.jupiter>
 
@@ -175,6 +178,11 @@
         <version>${version.com.squareup.okhttp3}</version>
       </dependency>
       <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${version.commons.codec}</version>
+      </dependency>
+      <dependency>
         <groupId>dnsjava</groupId>
         <artifactId>dnsjava</artifactId>
         <version>${version.dnsjava}</version>
@@ -224,6 +232,11 @@
         <groupId>io.ktor</groupId>
         <artifactId>ktor-serialization-kotlinx-json-jvm</artifactId>
         <version>${version.io.ktor}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${version.org.apache.httpcomponents.httpcore}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
## Notes to Reviewers

* Note the ⚠️  below and impact on versioning of `web5-kt` this carries via an API change.
* Please do not squash merge this PR; rebase merge is fine. We should preserve 1eb180c258d790822e77742b59d3f209dc7d6b3f so that it may be cleanly reverted as part of #328 

## In this PR

Reviewers, please assess impact of the following changes introduced by this PR:

* Create new module with `artifactId`: `web5-keymanager-aws`
* Add this new module to the `distribution`
* Move `AwsKeyManager` into it, along with `AwsKeyManagerTest`
*  ⚠️ Refactor package name of `AwsKeyManager` from `web5.sdk.crypto` to `web5.sdk.keymanager.aws`. This represents an API change and in strict terms would trigger a major version bump to a `2.x.y` series of `web5-kt` on the next release.
* Remove the `crypto` module dependency on `com.amazonaws:aws-java-sdk-kms`, the motivation behind this change and this PR.
* Add explicit `dependencyManagement` for `commons-codec:commons-codec`, needed in test scope by the `crypto` module which is no longer getting this transitively via `com.amazonaws:aws-java-sdk-kms`
* Add explicit `dependencyManagament` for `org.apache.httpcomponents:httpcore` and explicit declaration on it in `dids` module, which is no longer receiving this transitively since removing the `com.amazonaws:aws-java-sdk-kms` via `crypto`.