### PR TITLE
Add did id to root record name

### DIFF
--- a/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
+++ b/dids/src/main/kotlin/web5/sdk/dids/methods/dht/DidDht.kt
@@ -459,7 +459,7 @@ public sealed class DidDhtApi(configuration: DidDhtConfiguration) {
 
     message.addRecord(
       TXTRecord(
-        Name("_did."), DClass.IN, ttl, rootRecordText.joinToString(PROPERTY_SEPARATOR)
+        Name("_did.${didDocument.id.split(":")[2]}"), DClass.IN, ttl, rootRecordText.joinToString(PROPERTY_SEPARATOR)
       ), Section.ANSWER
     )
 


### PR DESCRIPTION
# Overview
Bugfix  in did:dht implementation

# Description
The did dht spec says that the root record should have name like `_did.<id>` where id is the last part of `did:dht:123` ([Source](https://did-dht.com/#root-record)).

# How Has This Been Tested?
_Describe the tests that you ran to verify your changes. Provide instructions for verification._

- [ ] Test A (e.g. Test A - New test that does ... run in ...)
- [ ] Test B

# Checklist

Before submitting this PR, please make sure:

- [ ] I have read the CONTRIBUTING document.
- [ ] My code is consistent with the rest of the project 
- [ ] I have tagged the relevant reviewers and/or interested parties
- [ ] I have updated the READMEs and other documentation of affected packages

## References
_Please list relevant documentation (e.g. tech specs, articles, follow up or related work) relevant to this change, and note if the documentation has been updated._
